### PR TITLE
add fastapi part in plugin

### DIFF
--- a/plugins/dogfooding-bundle/README.md
+++ b/plugins/dogfooding-bundle/README.md
@@ -1,6 +1,6 @@
 # Dogfooding Bundle Plugin
 
-Internal org bundle — install once, get all three capabilities.
+Internal org bundle — install once, get all bundled capabilities.
 
 > 中文文档见 [README_zh.md](README_zh.md)
 
@@ -13,6 +13,7 @@ Internal org bundle — install once, get all three capabilities.
 | **AgentScope Dogfooding Provider** | Registers the `agentscope-dogfooding` LLM Provider, routing requests through the AgentScope proxy |
 | **AgentTrack Startup Hook** | Initialises AgentTrack SDK (`app_name="qwenpaw"`) at application startup |
 | **/feedback Command** | Rewrites `/feedback` queries into agent prompts that guide the user through a feedback form |
+| **Dogfooding Account API** | Exposes `POST /api/dogfooding-account/` to save the dogfooding user account |
 
 ## Installation
 
@@ -84,12 +85,24 @@ User:  /feedback the result was wrong
 Agent: Based on your description, I understand your rating is: Poor ...
 ```
 
+### Dogfooding Account API
+
+Save the current dogfooding user account under QwenPaw's working directory:
+
+```bash
+curl -X POST http://127.0.0.1:8088/api/dogfooding-account/ \
+  -H 'Content-Type: application/json' \
+  -d '{"user_account":"12345567"}'
+```
+
+The API writes `dogfooding/user_account.json` in the QwenPaw working directory.
+
 ## File Structure
 
 ```
 dogfooding-bundle/
 ├── plugin.json          # Plugin manifest (type: bundle)
-├── plugin.py            # Entry point — single register() for all three capabilities
+├── plugin.py            # Entry point — single register() for all capabilities
 ├── query_rewriter.py    # Prompt rewriting logic for /feedback command
 ├── requirements.txt     # Python dependencies
 ├── README.md            # This file (English)
@@ -102,6 +115,7 @@ dogfooding-bundle/
 INFO | Dogfooding Bundle: AgentScope Dogfooding provider registered
 INFO | Dogfooding Bundle: AgentTrack startup hook registered
 INFO | Dogfooding Bundle: /feedback query-rewrite hook registered
+INFO | Dogfooding account API registered at POST /api/dogfooding-account/
 INFO | Dogfooding Bundle fully registered
 INFO | AgentTrack initialized (app_name=qwenpaw)
 INFO | Patched AgentRunner.query_handler for /feedback command

--- a/plugins/dogfooding-bundle/README_zh.md
+++ b/plugins/dogfooding-bundle/README_zh.md
@@ -1,6 +1,6 @@
 # Dogfooding Bundle 插件
 
-内部组织专属捆绑包，一次安装/卸载，三个能力全到位。
+内部组织专属捆绑包，一次安装/卸载，相关能力全到位。
 
 > English documentation: [README.md](README.md)
 
@@ -13,6 +13,7 @@
 | **AgentScope Dogfooding Provider** | 注册 `agentscope-dogfooding` LLM Provider，通过 AgentScope 代理路由请求 |
 | **AgentTrack 启动 Hook** | 应用启动时自动初始化 AgentTrack SDK（`app_name="qwenpaw"`） |
 | **/feedback 命令** | 将 `/feedback` 查询重写为 Agent Prompt，引导用户完成反馈表单 |
+| **Dogfooding Account API** | 暴露 `POST /api/dogfooding-account/`，保存 dogfooding 用户账号 |
 
 ## 安装
 
@@ -82,12 +83,24 @@ Agent: 感谢您的反馈！请对本次对话进行评价：...
 Agent: 根据您的描述，我理解您的评价是：糟糕...
 ```
 
+### Dogfooding Account API
+
+保存当前 dogfooding 用户账号到 QwenPaw 工作目录：
+
+```bash
+curl -X POST http://127.0.0.1:8088/api/dogfooding-account/ \
+  -H 'Content-Type: application/json' \
+  -d '{"user_account":"example"}'
+```
+
+接口会写入 QwenPaw 工作目录下的 `dogfooding/user_account.json`。
+
 ## 目录结构
 
 ```
 dogfooding-bundle/
 ├── plugin.json          # 插件清单（type: bundle）
-├── plugin.py            # 入口，单个 register() 注册三个能力
+├── plugin.py            # 入口，单个 register() 注册全部能力
 ├── query_rewriter.py    # /feedback 命令的 Prompt 重写逻辑
 ├── requirements.txt     # Python 依赖
 ├── README.md            # 英文文档
@@ -100,6 +113,7 @@ dogfooding-bundle/
 INFO | Dogfooding Bundle: AgentScope Dogfooding provider registered
 INFO | Dogfooding Bundle: AgentTrack startup hook registered
 INFO | Dogfooding Bundle: /feedback query-rewrite hook registered
+INFO | Dogfooding account API registered at POST /api/dogfooding-account/
 INFO | Dogfooding Bundle fully registered
 INFO | AgentTrack initialized (app_name=qwenpaw)
 INFO | Patched AgentRunner.query_handler for /feedback command

--- a/plugins/dogfooding-bundle/plugin.json
+++ b/plugins/dogfooding-bundle/plugin.json
@@ -3,7 +3,7 @@
   "name": "Dogfooding Bundle",
   "version": "1.0.0",
   "type": "bundle",
-  "description": "Internal org bundle: AgentScope provider, AgentTrack hook, and /feedback command",
+  "description": "Internal org bundle: AgentScope provider, AgentTrack hook, /feedback command, and dogfooding account API",
   "author": "QwenPaw Team",
   "entry": {
     "backend": "plugin.py"

--- a/plugins/dogfooding-bundle/plugin.py
+++ b/plugins/dogfooding-bundle/plugin.py
@@ -11,11 +11,19 @@ Internal org bundle that registers three capabilities in one shot:
      and overrides agentscope run_id for correct conversation.id
 3. /feedback command
    - Query-rewrite hook that turns /feedback into an agent prompt
+4. Dogfooding account API
+   - Saves dogfooding user_account.json under the QwenPaw working directory
 """
 
+import json
 import logging
 from contextvars import ContextVar
+from pathlib import Path
 
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from qwenpaw.constant import WORKING_DIR
 from qwenpaw.plugins.api import PluginApi
 from qwenpaw.providers.openai_provider import OpenAIProvider
 from qwenpaw.providers.provider import ModelInfo
@@ -59,6 +67,63 @@ class AgentScopeDogfoodingProvider(OpenAIProvider):
         return _DEFAULT_MODELS
 
 
+# ── Dogfooding account API ────────────────────────────────────────────────
+
+
+class DogfoodingAccountPayload(BaseModel):
+    """Request body for saving the dogfooding user account."""
+
+    user_account: str = Field(..., min_length=1)
+
+
+class DogfoodingAccountResponse(BaseModel):
+    """Response body after saving the dogfooding user account."""
+
+    ok: bool
+    path: str
+
+
+def _dogfooding_dir() -> Path:
+    return WORKING_DIR / "dogfooding"
+
+
+def _user_account_path() -> Path:
+    return _dogfooding_dir() / "user_account.json"
+
+
+def _build_dogfooding_account_router() -> APIRouter:
+    """Build routes mounted under /api/dogfooding-account."""
+    router = APIRouter()
+
+    @router.post("/", response_model=DogfoodingAccountResponse)
+    def save_user_account(
+        payload: DogfoodingAccountPayload,
+    ) -> DogfoodingAccountResponse:
+        """Save user_account.json under the QwenPaw working directory."""
+        target = _user_account_path()
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps(
+                    {"user_account": payload.user_account},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.exception("Failed to save dogfooding user account")
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to save user account",
+            ) from exc
+
+        return DogfoodingAccountResponse(ok=True, path=str(target))
+
+    return router
+
+
 # ── Bundle plugin ────────────────────────────────────────────────────────
 
 
@@ -78,6 +143,7 @@ class DogfoodingBundlePlugin:
         self._register_provider(api)
         self._register_agenttrack_hook(api)
         self._register_feedback_hook(api)
+        self._register_account_router(api)
         logger.info("Dogfooding Bundle fully registered")
 
     # ── provider ──────────────────────────────────────────────────────────
@@ -156,6 +222,20 @@ class DogfoodingBundlePlugin:
             priority=50,
         )
         logger.info("/feedback query-rewrite hook registered")
+
+    # ── dogfooding account API ────────────────────────────────────────────
+
+    def _register_account_router(self, api: PluginApi):
+        """Register the dogfooding account API router."""
+        api.register_http_router(
+            _build_dogfooding_account_router(),
+            prefix="/dogfooding-account",
+            tags=["dogfooding-account"],
+        )
+        logger.info(
+            "Dogfooding account API registered at "
+            "POST /api/dogfooding-account/",
+        )
 
     def _patch_query_handler(self):
         """Monkey-patch AgentRunner: inject trace attrs, rewrite /feedback."""


### PR DESCRIPTION
## Description

add fastAPI into plugin bundle:

usage: 

curl -X POST "http://127.0.0.1:8088/api/dogfooding-account/" \
  -H "Content-Type: application/json" \
  -d '{"user_account":"12345"}'
{"ok":true,"path":"/Users/liuyi/.copaw/dogfooding/user_account.json"}

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
