### PR TITLE
feat: add user-editable custom loop modes

### DIFF
--- a/console/src/api/types/agent.ts
+++ b/console/src/api/types/agent.ts
@@ -99,10 +99,47 @@ export interface RubricGateConfig {
   in_loop_modes: boolean;
 }
 
+export type CustomGateType =
+  | "iteration"
+  | "doom_loop"
+  | "token_budget"
+  | "timeout"
+  | "tool_call_budget"
+  | "text_response_retry"
+  | "completion_rubric";
+
+export interface GateInstanceConfig {
+  id: string;
+  type: CustomGateType;
+  enabled: boolean;
+  params: Record<string, unknown>;
+}
+
+export interface CustomLoopModeConfig {
+  id: string;
+  name: string;
+  description: string;
+  slash_command: string;
+  enabled: boolean;
+  gates: GateInstanceConfig[];
+}
+
+export interface GoalLoopModeConfig {
+  max_iterations: number;
+  max_tokens: number;
+}
+
+export interface MissionLoopModeConfig {
+  max_iterations: number;
+}
+
 export interface LoopConfig {
   iteration?: IterationGateConfig;
   doom_loop: DoomLoopConfig;
   rubric?: RubricGateConfig;
+  goal?: GoalLoopModeConfig;
+  mission?: MissionLoopModeConfig;
+  custom_modes?: CustomLoopModeConfig[];
 }
 
 export interface AgentsRunningConfig {

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.module.less
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.module.less
@@ -1,0 +1,375 @@
+.loopCard {
+  overflow: hidden;
+
+  :global(.ant-card-body) {
+    padding-top: 8px;
+  }
+
+  :global(.ant-tabs-nav-wrap) {
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+}
+
+.builtInTab,
+.customTab,
+.builtInTag,
+.customTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.builtInTab {
+  color: var(--text-secondary, rgba(0, 0, 0, 0.55));
+}
+
+.customTab {
+  position: relative;
+  padding: 3px 9px 3px 18px;
+  border-radius: 8px;
+  background: #e4ede7;
+  color: #315c4b;
+
+  &::before {
+    position: absolute;
+    left: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #5f8d76;
+    content: "";
+  }
+}
+
+.addModeButton {
+  margin-left: 8px;
+  border-color: #abc0b5;
+  background: #e4ede7;
+  color: #315c4b;
+}
+
+.modeEditor {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 16px 4px 12px;
+}
+
+.modeHeader,
+.customHeader {
+  margin-bottom: 24px;
+}
+
+.modeHeader h3 {
+  margin: 10px 0 5px;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.modeHeader > p,
+.customHeader p {
+  margin: 0 0 14px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.55));
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.builtInTag,
+.customTag {
+  margin: 0;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.customTag {
+  border-color: #bdcec5;
+  background: #e4ede7;
+  color: #315c4b;
+}
+
+.customHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.customHeader p {
+  margin-top: 8px;
+  margin-bottom: 0;
+}
+
+.pipelineHeader {
+  margin-bottom: 10px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.55));
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.gateList {
+  display: grid;
+  gap: 10px;
+}
+
+.gateCard {
+  overflow: hidden;
+  margin-bottom: 10px;
+  border: 1px solid var(--border-color, #e1e3df);
+  border-radius: 13px;
+  background: var(--background-color, #fff);
+}
+
+.gateSummary {
+  display: grid;
+  width: 100%;
+  min-height: 66px;
+  grid-template-columns: 28px 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 13px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.lockSlot,
+.dragHandle {
+  display: grid;
+  width: 28px;
+  height: 32px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-quaternary, rgba(0, 0, 0, 0.3));
+}
+
+.dragHandle {
+  cursor: grab;
+}
+
+.gateIcon {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 9px;
+  background: #f0f2ee;
+  color: #4c5a52;
+}
+
+.gateCopy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.gateCopy strong {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.gateCopy small {
+  overflow: hidden;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.5));
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gateActions {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+
+.moveUp {
+  transform: rotate(180deg);
+}
+
+.gateDetails {
+  padding: 18px 20px 4px 82px;
+  border-top: 1px solid var(--border-color, #eceeea);
+  background: var(--background-color-secondary, #fdfdfb);
+}
+
+.gateDetails :global(.ant-form-item:last-child) {
+  margin-bottom: 14px;
+}
+
+.readOnlyCopy {
+  margin: 0 0 16px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.55));
+  font-size: 12px;
+}
+
+.fieldGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.pipelineToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 6px 0 12px;
+}
+
+.pipelineToolbar > div {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.pipelineToolbar small {
+  color: var(--text-secondary, rgba(0, 0, 0, 0.45));
+}
+
+.addGateSelect {
+  width: 190px;
+}
+
+.emptyPipeline {
+  padding: 38px 18px;
+  border: 1px dashed var(--border-color, #d4d8d2);
+  border-radius: 13px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.5));
+  text-align: center;
+}
+
+.criteriaList {
+  display: grid;
+  gap: 9px;
+  margin-bottom: 16px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.criterionRow {
+  display: grid;
+  grid-template-columns: 24px minmax(180px, 1fr) 72px 84px 32px;
+  align-items: center;
+  gap: 8px;
+}
+
+.criterionRow > span {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 7px;
+  background: #e4ede7;
+  color: #315c4b;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.inlineControl {
+  display: grid;
+  justify-items: start;
+  gap: 3px;
+}
+
+.inlineControl small {
+  color: var(--text-secondary, rgba(0, 0, 0, 0.5));
+  font-size: 9px;
+}
+
+.inlineControl :global(.ant-input-number) {
+  width: 78px;
+}
+
+.toolLimitList {
+  display: grid;
+  gap: 8px;
+}
+
+.toolLimitRow {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 100px 32px;
+  gap: 8px;
+}
+
+.createForm {
+  display: grid;
+  gap: 9px;
+  padding-top: 8px;
+}
+
+.createForm label {
+  margin-top: 4px;
+  color: var(--text-secondary, rgba(0, 0, 0, 0.65));
+  font-size: 12px;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .modeEditor {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .fieldGrid {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .customHeader,
+  .pipelineToolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .addGateSelect {
+    width: 100%;
+  }
+
+  .gateSummary {
+    grid-template-columns: 22px 32px minmax(0, 1fr) auto;
+    gap: 7px;
+    padding-right: 7px;
+    padding-left: 7px;
+  }
+
+  .gateDetails {
+    padding-right: 13px;
+    padding-left: 13px;
+  }
+
+  .gateActions > :nth-child(-n + 2) {
+    display: none;
+  }
+
+  .criterionRow {
+    grid-template-columns: 24px minmax(0, 1fr) 32px;
+  }
+
+  .criterionRow .inlineControl {
+    grid-column: 2;
+  }
+
+  .criterionRow > button {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .toolLimitRow {
+    grid-template-columns: minmax(0, 1fr) 88px 32px;
+  }
+}

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.test.ts
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { GateInstanceConfig } from "@/api/types";
+import { buildCustomLoopMode, reorderCustomGates } from "./AgentLoopCard";
+
+describe("buildCustomLoopMode", () => {
+  it("creates multiple custom modes with unique tab identity", () => {
+    const first = buildCustomLoopMode([], "Research", "research", "safe", 1);
+    const second = buildCustomLoopMode(
+      [first],
+      "Research Copy",
+      "research",
+      "quality",
+      2,
+    );
+
+    expect(first.id).toBe("research");
+    expect(second.id).toBe("research-2");
+    expect(second.slash_command).toBe("research-2");
+    expect(second.gates.map((gate) => gate.type)).toEqual([
+      "iteration",
+      "token_budget",
+      "doom_loop",
+      "completion_rubric",
+    ]);
+  });
+
+  it("keeps blank modes disabled until a gate is added", () => {
+    const mode = buildCustomLoopMode([], "Draft", "draft", "blank", 1);
+
+    expect(mode.enabled).toBe(false);
+    expect(mode.gates).toEqual([]);
+  });
+});
+
+describe("reorderCustomGates", () => {
+  it("uses the visible pipeline order as the source of truth", () => {
+    const gates = [
+      { id: "one", type: "iteration" },
+      { id: "two", type: "timeout" },
+      { id: "three", type: "doom_loop" },
+    ].map(
+      (gate) =>
+        ({
+          ...gate,
+          enabled: true,
+          params: {},
+        }) as GateInstanceConfig,
+    );
+
+    expect(reorderCustomGates(gates, 2, 0).map((gate) => gate.id)).toEqual([
+      "three",
+      "one",
+      "two",
+    ]);
+  });
+});

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Tabs,
   Tag,
+  Modal,
 } from "@agentscope-ai/design";
 import {
   Plus,
@@ -25,9 +26,35 @@ import {
   Gauge,
   Wallet,
   Lock,
+  GripVertical,
+  Clock3,
+  Wrench,
+  ListChecks,
+  Copy,
+  Sparkles,
 } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useTranslation } from "react-i18next";
+import type {
+  CustomGateType,
+  CustomLoopModeConfig,
+  GateInstanceConfig,
+} from "@/api/types";
 import styles from "../index.module.less";
+import loopStyles from "./AgentLoopCard.module.less";
 
 const ACTION_OPTIONS = [
   { value: "modify_prompt", label: "Send Reminder" },
@@ -54,95 +81,6 @@ function SectionHeader({
     >
       {icon}
       <span style={{ fontWeight: 600, fontSize: 14 }}>{title}</span>
-    </div>
-  );
-}
-
-function SectionDivider() {
-  return (
-    <hr
-      style={{
-        border: "none",
-        borderTop: "1px solid var(--border-color, #f0f0f0)",
-        margin: "24px 0",
-      }}
-    />
-  );
-}
-
-function MockGateCard({
-  icon,
-  title,
-  description,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div
-      style={{
-        border: "1px solid var(--border-color, #f0f0f0)",
-        borderRadius: 8,
-        padding: "16px 20px",
-        marginBottom: 12,
-        opacity: 0.6,
-        position: "relative",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          {icon}
-          <span style={{ fontWeight: 500, fontSize: 13 }}>{title}</span>
-        </div>
-        <Tag
-          style={{
-            fontSize: 11,
-            borderRadius: 4,
-            display: "flex",
-            alignItems: "center",
-            gap: 4,
-          }}
-        >
-          <Lock size={10} />
-          {t("agentConfig.comingSoon", "Coming Soon")}
-        </Tag>
-      </div>
-      <p
-        style={{
-          margin: "8px 0 0",
-          fontSize: 12,
-          color: "var(--text-secondary, rgba(0,0,0,0.45))",
-        }}
-      >
-        {description}
-      </p>
-      <p
-        style={{
-          margin: "6px 0 0",
-          fontSize: 11,
-          color: "var(--text-quaternary, rgba(0,0,0,0.25))",
-          fontStyle: "italic",
-        }}
-      >
-        {t(
-          "agentConfig.comingSoonEditable",
-          "Custom configuration will be available in a future release.",
-        )}
-      </p>
     </div>
   );
 }
@@ -533,139 +471,860 @@ function RubricSection() {
   );
 }
 
-function ReactTab() {
+function LockedGateCard({
+  icon,
+  title,
+  description,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
   return (
-    <>
-      <IterationSection />
-      <SectionDivider />
-      <DoomLoopSection />
-      <SectionDivider />
-      <RubricSection />
-    </>
+    <div className={loopStyles.gateCard}>
+      <button
+        type="button"
+        className={loopStyles.gateSummary}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span className={loopStyles.lockSlot}>
+          <Lock size={14} />
+        </span>
+        <span className={loopStyles.gateIcon}>{icon}</span>
+        <span className={loopStyles.gateCopy}>
+          <strong>{title}</strong>
+          <small>{description}</small>
+        </span>
+        {expanded ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+      </button>
+      {expanded && <div className={loopStyles.gateDetails}>{children}</div>}
+    </div>
   );
 }
 
-function GoalModeTab() {
-  const { t } = useTranslation();
+function BuiltInHeader({
+  name,
+  description,
+}: {
+  name: string;
+  description: string;
+}) {
   return (
-    <div>
+    <div className={loopStyles.modeHeader}>
+      <Tag className={loopStyles.builtInTag}>
+        <Lock size={11} /> Built-in
+      </Tag>
+      <h3>{name}</h3>
+      <p>{description}</p>
       <Alert
         type="info"
         showIcon
         icon={<Info size={14} />}
-        message={t("agentConfig.goalModeInfoTitle", "Goal Mode vs Default")}
-        description={t(
-          "agentConfig.goalModeInfo",
-          "Default mode stops after a single reply. Goal mode keeps the agent looping toward a goal, using Rubric evaluation to determine completion. All operations run within the current agent context.",
-        )}
-        style={{ marginBottom: 16 }}
+        message="Components and order are locked. Gate values remain editable."
       />
-      <MockGateCard
-        icon={<Repeat size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.goalIterationGate", "Goal Iteration Gate")}
-        description={t(
-          "agentConfig.goalIterationGateDesc",
-          "Limits the number of agent turns within a goal session. Tracks iteration count and token usage.",
-        )}
+    </div>
+  );
+}
+
+function DefaultModeTab() {
+  return (
+    <div className={loopStyles.modeEditor}>
+      <BuiltInHeader
+        name="Default"
+        description="The standard guarded ReAct loop used outside an explicit mode."
       />
-      <MockGateCard
-        icon={<Wallet size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.goalBudgetGate", "Token Budget Gate")}
-        description={t(
-          "agentConfig.goalBudgetGateDesc",
-          "Enforces a token spending limit for the goal session. Stops the agent when budget is exceeded.",
-        )}
+      <div className={loopStyles.pipelineHeader}>Gate pipeline</div>
+      <LockedGateCard
+        icon={<Shield size={15} />}
+        title="Repetition protection"
+        description="Detect repeated tool calls and intervene."
+      >
+        <DoomLoopSection />
+      </LockedGateCard>
+      <LockedGateCard
+        icon={<Repeat size={15} />}
+        title="Iteration limit"
+        description="Bound the number of ReAct iterations."
+      >
+        <IterationSection />
+      </LockedGateCard>
+      <LockedGateCard
+        icon={<CheckCircle size={15} />}
+        title="Early-stop retry"
+        description="Verify text-only completion before stopping."
+      >
+        <RubricSection />
+      </LockedGateCard>
+    </div>
+  );
+}
+
+function GoalModeTab() {
+  return (
+    <div className={loopStyles.modeEditor}>
+      <BuiltInHeader
+        name="Goal"
+        description="A bounded persistent loop for concrete, verifiable goals."
       />
-      <MockGateCard
-        icon={<CheckCircle size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.goalRubricGate", "Goal Completion Rubric")}
-        description={t(
-          "agentConfig.goalRubricGateDesc",
-          "Evaluates whether the goal has been achieved by checking the session status.",
-        )}
-      />
-      <MockGateCard
-        icon={<Shield size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.goalDoomGate", "Repetition Protection")}
-        description={t(
-          "agentConfig.goalDoomGateDesc",
-          "Detects repetitive patterns during goal execution and triggers intervention.",
-        )}
-      />
+      <div className={loopStyles.pipelineHeader}>Gate pipeline</div>
+      <LockedGateCard
+        icon={<Target size={15} />}
+        title="Goal turn limit"
+        description="Limit turns within one active goal."
+      >
+        <Form.Item
+          name={["loop", "goal", "max_iterations"]}
+          label="Maximum goal turns"
+        >
+          <InputNumber min={1} max={500} style={{ width: 220 }} />
+        </Form.Item>
+      </LockedGateCard>
+      <LockedGateCard
+        icon={<Wallet size={15} />}
+        title="Goal token budget"
+        description="Stop when the complete goal reaches its budget."
+      >
+        <Form.Item
+          name={["loop", "goal", "max_tokens"]}
+          label="Maximum goal tokens"
+        >
+          <InputNumber min={1} style={{ width: 220 }} />
+        </Form.Item>
+      </LockedGateCard>
+      <LockedGateCard
+        icon={<CheckCircle size={15} />}
+        title="Goal completion check"
+        description="Read the explicit goal status before stopping."
+      >
+        <p className={loopStyles.readOnlyCopy}>
+          Completion is controlled by the built-in goal status protocol.
+        </p>
+      </LockedGateCard>
     </div>
   );
 }
 
 function MissionModeTab() {
-  const { t } = useTranslation();
   return (
-    <div>
-      <Alert
-        type="info"
-        showIcon
-        icon={<Info size={14} />}
-        message={t(
-          "agentConfig.missionModeInfoTitle",
-          "Mission Mode vs Goal Mode",
-        )}
-        description={t(
-          "agentConfig.missionModeInfo",
-          "Mission mode decomposes complex tasks and delegates sub-tasks to independent sub-agents. Each sub-task runs in its own context, preventing context pollution of the main session. Best for complex engineering tasks.",
-        )}
-        style={{ marginBottom: 16 }}
+    <div className={loopStyles.modeEditor}>
+      <BuiltInHeader
+        name="Mission"
+        description="A persistent pipeline for longer-running, multi-step missions."
       />
-      <MockGateCard
-        icon={<Gauge size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.missionProgressGate", "Mission Progress Gate")}
-        description={t(
-          "agentConfig.missionProgressGateDesc",
-          "Tracks PRD user story completion. Continues until all stories pass or max iterations reached.",
-        )}
-      />
-      <MockGateCard
-        icon={<Repeat size={14} style={{ opacity: 0.5 }} />}
-        title={t("agentConfig.missionIterBypass", "Iteration Bypass")}
-        description={t(
-          "agentConfig.missionIterBypassDesc",
-          "Temporarily lifts the ReAct iteration limit during mission execution to allow long-running phases.",
-        )}
-      />
+      <div className={loopStyles.pipelineHeader}>Gate pipeline</div>
+      <LockedGateCard
+        icon={<Rocket size={15} />}
+        title="Mission progress check"
+        description="Continue until mission stories pass or the limit is reached."
+      >
+        <Form.Item
+          name={["loop", "mission", "max_iterations"]}
+          label="Default mission iterations"
+        >
+          <InputNumber min={1} max={100} style={{ width: 220 }} />
+        </Form.Item>
+      </LockedGateCard>
     </div>
   );
 }
 
+type GateDefinition = {
+  type: CustomGateType;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  defaults: Record<string, unknown>;
+};
+
+function PerToolLimits({
+  value = {},
+  onChange,
+}: {
+  value?: Record<string, number>;
+  onChange?: (value: Record<string, number>) => void;
+}) {
+  const entries = Object.entries(value);
+  const updateName = (oldName: string, nextName: string) => {
+    const normalized = nextName.trim();
+    if (!normalized || (normalized !== oldName && normalized in value)) return;
+    const next = { ...value };
+    const limit = next[oldName];
+    delete next[oldName];
+    next[normalized] = limit;
+    onChange?.(next);
+  };
+  const updateLimit = (name: string, limit: number | null) =>
+    onChange?.({ ...value, [name]: limit || 1 });
+  const addLimit = () => {
+    let name = "tool-name";
+    let suffix = 2;
+    while (name in value) {
+      name = `tool-name-${suffix}`;
+      suffix += 1;
+    }
+    onChange?.({ ...value, [name]: 3 });
+  };
+
+  return (
+    <div className={loopStyles.toolLimitList}>
+      {entries.map(([name, limit]) => (
+        <div className={loopStyles.toolLimitRow} key={name}>
+          <Input
+            value={name}
+            aria-label="Tool name"
+            onBlur={(event) => updateName(name, event.target.value)}
+            onPressEnter={(event) =>
+              updateName(name, event.currentTarget.value)
+            }
+          />
+          <InputNumber
+            min={1}
+            max={10000}
+            value={limit}
+            aria-label={`${name} call limit`}
+            onChange={(next) => updateLimit(name, next)}
+          />
+          <Button
+            type="text"
+            icon={<Trash2 size={14} />}
+            aria-label={`Remove ${name} limit`}
+            onClick={() => {
+              const next = { ...value };
+              delete next[name];
+              onChange?.(next);
+            }}
+          />
+        </div>
+      ))}
+      <Button icon={<Plus size={14} />} onClick={addLimit}>
+        Add per-tool limit
+      </Button>
+    </div>
+  );
+}
+
+const GATE_DEFINITIONS: GateDefinition[] = [
+  {
+    type: "iteration",
+    title: "Iteration limit",
+    description: "Stop after a fixed number of loop iterations.",
+    icon: <Repeat size={15} />,
+    defaults: { max_iterations: 40 },
+  },
+  {
+    type: "doom_loop",
+    title: "Repetition protection",
+    description: "Detect repeated tool calls and change strategy.",
+    icon: <Shield size={15} />,
+    defaults: { window_size: 3, similarity_threshold: 1 },
+  },
+  {
+    type: "token_budget",
+    title: "Token budget",
+    description: "Limit prompt and completion token usage.",
+    icon: <Gauge size={15} />,
+    defaults: { max_total_tokens: 120000 },
+  },
+  {
+    type: "timeout",
+    title: "Time limit",
+    description: "Stop at a loop boundary after elapsed time.",
+    icon: <Clock3 size={15} />,
+    defaults: { max_seconds: 1800 },
+  },
+  {
+    type: "tool_call_budget",
+    title: "Tool-call budget",
+    description: "Limit all calls and selected tools.",
+    icon: <Wrench size={15} />,
+    defaults: { max_calls: 30, per_tool: {} },
+  },
+  {
+    type: "text_response_retry",
+    title: "Early-stop retry",
+    description: "Prompt the agent to verify before ending.",
+    icon: <CheckCircle size={15} />,
+    defaults: {
+      prompt: "Verify the task before stopping. Continue if work remains.",
+      max_interventions: 1,
+    },
+  },
+  {
+    type: "completion_rubric",
+    title: "Completion rubric",
+    description: "Evaluate explicit criteria and revise when needed.",
+    icon: <ListChecks size={15} />,
+    defaults: {
+      criteria: [
+        {
+          id: "complete-request",
+          description: "Every explicit requirement is addressed.",
+          required: true,
+          weight: 1,
+        },
+      ],
+      pass_threshold: 1,
+      max_revisions: 2,
+      evaluate_when: "text_response",
+      include_last_tool_results: 5,
+      on_grader_error: "stop",
+    },
+  },
+];
+
+function gateDefinition(type: CustomGateType) {
+  return GATE_DEFINITIONS.find((item) => item.type === type)!;
+}
+
+function GateParamsEditor({
+  modeIndex,
+  gateIndex,
+  type,
+}: {
+  modeIndex: number;
+  gateIndex: number;
+  type: CustomGateType;
+}) {
+  const base = [
+    "loop",
+    "custom_modes",
+    modeIndex,
+    "gates",
+    gateIndex,
+    "params",
+  ];
+  if (type === "iteration") {
+    return (
+      <Form.Item name={[...base, "max_iterations"]} label="Maximum iterations">
+        <InputNumber min={1} max={500} style={{ width: "100%" }} />
+      </Form.Item>
+    );
+  }
+  if (type === "doom_loop") {
+    return (
+      <div className={loopStyles.fieldGrid}>
+        <Form.Item name={[...base, "window_size"]} label="History window">
+          <InputNumber min={2} max={20} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item
+          name={[...base, "similarity_threshold"]}
+          label="Similarity threshold"
+        >
+          <InputNumber min={0} max={1} step={0.05} style={{ width: "100%" }} />
+        </Form.Item>
+      </div>
+    );
+  }
+  if (type === "token_budget") {
+    return (
+      <>
+        <div className={loopStyles.fieldGrid}>
+          <Form.Item name={[...base, "max_total_tokens"]} label="Total tokens">
+            <InputNumber min={1} style={{ width: "100%" }} />
+          </Form.Item>
+          <Form.Item
+            name={[...base, "max_prompt_tokens"]}
+            label="Prompt tokens"
+          >
+            <InputNumber min={1} style={{ width: "100%" }} />
+          </Form.Item>
+        </div>
+        <Form.Item
+          name={[...base, "max_completion_tokens"]}
+          label="Completion tokens"
+        >
+          <InputNumber min={1} style={{ width: "100%" }} />
+        </Form.Item>
+      </>
+    );
+  }
+  if (type === "timeout") {
+    return (
+      <Form.Item name={[...base, "max_seconds"]} label="Maximum seconds">
+        <InputNumber min={1} max={86400} style={{ width: "100%" }} />
+      </Form.Item>
+    );
+  }
+  if (type === "tool_call_budget") {
+    return (
+      <>
+        <Form.Item name={[...base, "max_calls"]} label="All tool calls">
+          <InputNumber min={1} max={10000} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item name={[...base, "per_tool"]} label="Per-tool limits">
+          <PerToolLimits />
+        </Form.Item>
+      </>
+    );
+  }
+  if (type === "text_response_retry") {
+    return (
+      <>
+        <Form.Item
+          name={[...base, "max_interventions"]}
+          label="Maximum retries"
+        >
+          <InputNumber min={1} max={10} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item name={[...base, "prompt"]} label="Retry instruction">
+          <Input.TextArea autoSize={{ minRows: 2, maxRows: 5 }} />
+        </Form.Item>
+      </>
+    );
+  }
+  return (
+    <>
+      <div className={loopStyles.fieldGrid}>
+        <Form.Item name={[...base, "pass_threshold"]} label="Pass threshold">
+          <InputNumber min={0} max={1} step={0.05} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item name={[...base, "max_revisions"]} label="Maximum revisions">
+          <InputNumber min={0} max={10} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item
+          name={[...base, "include_last_tool_results"]}
+          label="Tool results as evidence"
+        >
+          <InputNumber min={0} max={20} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item name={[...base, "on_grader_error"]} label="Grader error">
+          <Select
+            options={[
+              { value: "stop", label: "Stop safely" },
+              { value: "continue_once", label: "Verify once more" },
+            ]}
+          />
+        </Form.Item>
+      </div>
+      <Form.List name={[...base, "criteria"]}>
+        {(fields, { add, remove }) => (
+          <div className={loopStyles.criteriaList}>
+            <span className={loopStyles.fieldLabel}>Completion criteria</span>
+            {fields.map((field, index) => (
+              <div className={loopStyles.criterionRow} key={field.key}>
+                <span>{index + 1}</span>
+                <Form.Item name={[field.name, "id"]} hidden>
+                  <Input />
+                </Form.Item>
+                <Form.Item name={[field.name, "description"]} noStyle>
+                  <Input placeholder="Describe observable completion" />
+                </Form.Item>
+                <label className={loopStyles.inlineControl}>
+                  <small>Required</small>
+                  <Form.Item
+                    name={[field.name, "required"]}
+                    valuePropName="checked"
+                    noStyle
+                  >
+                    <Switch size="small" />
+                  </Form.Item>
+                </label>
+                <label className={loopStyles.inlineControl}>
+                  <small>Weight</small>
+                  <Form.Item name={[field.name, "weight"]} noStyle>
+                    <InputNumber min={0.1} max={100} step={0.1} />
+                  </Form.Item>
+                </label>
+                <Button
+                  type="text"
+                  icon={<Trash2 size={14} />}
+                  onClick={() => remove(field.name)}
+                />
+              </div>
+            ))}
+            <Button
+              icon={<Plus size={14} />}
+              onClick={() =>
+                add({
+                  id: `criterion-${fields.length + 1}`,
+                  description: "",
+                  required: true,
+                  weight: 1,
+                })
+              }
+            >
+              Add criterion
+            </Button>
+          </div>
+        )}
+      </Form.List>
+    </>
+  );
+}
+
+function SortableGateCard({
+  modeIndex,
+  gateIndex,
+  gate,
+  onRemove,
+  onMove,
+}: {
+  modeIndex: number;
+  gateIndex: number;
+  gate: GateInstanceConfig;
+  onRemove: () => void;
+  onMove: (offset: number) => void;
+}) {
+  const [expanded, setExpanded] = useState(gate.type === "completion_rubric");
+  const definition = gateDefinition(gate.type);
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: gate.id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={loopStyles.gateCard}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+    >
+      <div className={loopStyles.gateSummary}>
+        <button
+          type="button"
+          className={loopStyles.dragHandle}
+          {...attributes}
+          {...listeners}
+          aria-label={`Move ${definition.title}`}
+        >
+          <GripVertical size={15} />
+        </button>
+        <span className={loopStyles.gateIcon}>{definition.icon}</span>
+        <button
+          type="button"
+          className={loopStyles.gateCopy}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          <strong>{definition.title}</strong>
+          <small>{definition.description}</small>
+        </button>
+        <div className={loopStyles.gateActions}>
+          <Button type="text" size="small" onClick={() => onMove(-1)}>
+            <ChevronDown className={loopStyles.moveUp} size={14} />
+          </Button>
+          <Button type="text" size="small" onClick={() => onMove(1)}>
+            <ChevronDown size={14} />
+          </Button>
+          <Button
+            type="text"
+            size="small"
+            icon={<Trash2 size={14} />}
+            onClick={onRemove}
+          />
+          <Button
+            type="text"
+            size="small"
+            icon={
+              expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />
+            }
+            onClick={() => setExpanded((value) => !value)}
+          />
+        </div>
+      </div>
+      {expanded && (
+        <div className={loopStyles.gateDetails}>
+          <GateParamsEditor
+            modeIndex={modeIndex}
+            gateIndex={gateIndex}
+            type={gate.type}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CustomModeEditor({
+  modeIndex,
+  onDelete,
+  onDuplicate,
+}: {
+  modeIndex: number;
+  onDelete: () => void;
+  onDuplicate: () => void;
+}) {
+  const form = Form.useFormInstance();
+  const gates =
+    (Form.useWatch(
+      ["loop", "custom_modes", modeIndex, "gates"],
+      form,
+    ) as GateInstanceConfig[]) || [];
+  const sensors = useSensors(useSensor(PointerSensor));
+  const path = ["loop", "custom_modes", modeIndex, "gates"];
+  const updateGates = (next: GateInstanceConfig[]) =>
+    form.setFieldValue(path, next);
+  const usedTypes = new Set(gates.map((gate) => gate.type));
+  const available = GATE_DEFINITIONS.filter(
+    (definition) =>
+      !usedTypes.has(definition.type) &&
+      !(
+        definition.type === "completion_rubric" &&
+        usedTypes.has("text_response_retry")
+      ) &&
+      !(
+        definition.type === "text_response_retry" &&
+        usedTypes.has("completion_rubric")
+      ),
+  );
+
+  const addGate = (type: CustomGateType) => {
+    const definition = gateDefinition(type);
+    updateGates([
+      ...gates,
+      {
+        id: `${type}-${Date.now()}`,
+        type,
+        enabled: true,
+        params: structuredClone(definition.defaults),
+      },
+    ]);
+  };
+  const moveGate = (index: number, offset: number) => {
+    const target = index + offset;
+    if (target < 0 || target >= gates.length) return;
+    updateGates(reorderCustomGates(gates, index, target));
+  };
+  const removeGate = (index: number) => {
+    const next = gates.filter((_, itemIndex) => itemIndex !== index);
+    updateGates(next);
+    if (!next.length) {
+      form.setFieldValue(["loop", "custom_modes", modeIndex, "enabled"], false);
+    }
+  };
+  const onDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const from = gates.findIndex((gate) => gate.id === active.id);
+    const to = gates.findIndex((gate) => gate.id === over.id);
+    updateGates(reorderCustomGates(gates, from, to));
+  };
+
+  return (
+    <div className={loopStyles.modeEditor}>
+      <div className={loopStyles.customHeader}>
+        <div>
+          <Tag className={loopStyles.customTag}>
+            <Sparkles size={11} /> Custom
+          </Tag>
+          <p>Build a saved pipeline from QwenPaw-owned gates.</p>
+        </div>
+        <div>
+          <Button type="text" icon={<Copy size={14} />} onClick={onDuplicate}>
+            Duplicate
+          </Button>
+          <Button
+            danger
+            type="text"
+            icon={<Trash2 size={14} />}
+            onClick={onDelete}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+      <div className={loopStyles.fieldGrid}>
+        <Form.Item
+          name={["loop", "custom_modes", modeIndex, "name"]}
+          label="Display name"
+          rules={[{ required: true }]}
+        >
+          <Input maxLength={80} />
+        </Form.Item>
+        <Form.Item
+          name={["loop", "custom_modes", modeIndex, "slash_command"]}
+          label="Slash command"
+          rules={[{ required: true }, { pattern: /^[a-z0-9][a-z0-9_-]*$/ }]}
+        >
+          <Input prefix="/" maxLength={64} />
+        </Form.Item>
+      </div>
+      <Form.Item
+        name={["loop", "custom_modes", modeIndex, "description"]}
+        label="Description"
+      >
+        <Input.TextArea autoSize={{ minRows: 2, maxRows: 4 }} maxLength={500} />
+      </Form.Item>
+      <Form.Item
+        name={["loop", "custom_modes", modeIndex, "enabled"]}
+        label="Available to this agent"
+        valuePropName="checked"
+      >
+        <Switch disabled={!gates.length} />
+      </Form.Item>
+
+      <div className={loopStyles.pipelineToolbar}>
+        <div>
+          <strong>Gate pipeline</strong>
+          <small>Runs from top to bottom</small>
+        </div>
+        <Select<CustomGateType>
+          placeholder="Add gate"
+          className={loopStyles.addGateSelect}
+          options={available.map((definition) => ({
+            value: definition.type,
+            label: definition.title,
+          }))}
+          onChange={addGate}
+          disabled={!available.length}
+        />
+      </div>
+      {!gates.length ? (
+        <div className={loopStyles.emptyPipeline}>
+          Add at least one gate before enabling this mode.
+        </div>
+      ) : (
+        <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+          <SortableContext
+            items={gates.map((gate) => gate.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className={loopStyles.gateList}>
+              {gates.map((gate, index) => (
+                <SortableGateCard
+                  key={gate.id}
+                  modeIndex={modeIndex}
+                  gateIndex={index}
+                  gate={gate}
+                  onRemove={() => removeGate(index)}
+                  onMove={(offset) => moveGate(index, offset)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+    </div>
+  );
+}
+
+const TEMPLATES: Record<string, CustomGateType[]> = {
+  safe: ["iteration", "token_budget", "doom_loop", "text_response_retry"],
+  research: ["iteration", "timeout", "tool_call_budget", "doom_loop"],
+  quality: ["iteration", "token_budget", "doom_loop", "completion_rubric"],
+  blank: [],
+};
+
+function makeGate(
+  type: CustomGateType,
+  nonce = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+): GateInstanceConfig {
+  const definition = gateDefinition(type);
+  return {
+    id: `${type}-${nonce}`,
+    type,
+    enabled: true,
+    params: structuredClone(definition.defaults),
+  };
+}
+
+export function buildCustomLoopMode(
+  existing: CustomLoopModeConfig[],
+  name: string,
+  command: string,
+  template: string,
+  nonce = Date.now(),
+): CustomLoopModeConfig {
+  const baseCommand = command || "custom-mode";
+  const slashCommand = uniqueValue(
+    baseCommand,
+    new Set(existing.map((mode) => mode.slash_command)),
+  );
+  const id = uniqueValue(baseCommand, new Set(existing.map((mode) => mode.id)));
+  return {
+    id,
+    name,
+    slash_command: slashCommand,
+    description: "A custom gate pipeline.",
+    enabled: template !== "blank",
+    gates: TEMPLATES[template].map((type, index) =>
+      makeGate(type, `${nonce}-${index}`),
+    ),
+  };
+}
+
+function uniqueValue(base: string, existing: Set<string>): string {
+  let candidate = base;
+  let suffix = 2;
+  while (existing.has(candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+export function reorderCustomGates(
+  gates: GateInstanceConfig[],
+  from: number,
+  to: number,
+): GateInstanceConfig[] {
+  if (from < 0 || to < 0 || from >= gates.length || to >= gates.length) {
+    return gates;
+  }
+  return arrayMove(gates, from, to);
+}
+
 export function AgentLoopCard() {
   const { t } = useTranslation();
+  const form = Form.useFormInstance();
+  const customModes =
+    (Form.useWatch(["loop", "custom_modes"], form) as CustomLoopModeConfig[]) ||
+    [];
+  const [activeKey, setActiveKey] = useState("default");
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("New Loop Mode");
+  const [newCommand, setNewCommand] = useState("new-mode");
+  const [template, setTemplate] = useState("safe");
+
+  const setModes = (modes: CustomLoopModeConfig[]) =>
+    form.setFieldValue(["loop", "custom_modes"], modes);
+  const createMode = () => {
+    const mode = buildCustomLoopMode(
+      customModes,
+      newName,
+      newCommand,
+      template,
+    );
+    setModes([...customModes, mode]);
+    setActiveKey(`custom:${mode.id}`);
+    setCreating(false);
+  };
+  const duplicateMode = (index: number) => {
+    const source = customModes[index];
+    const baseId = `${source.id}-copy`;
+    const baseCommand = `${source.slash_command}-copy`;
+    const copy: CustomLoopModeConfig = {
+      ...structuredClone(source),
+      id: uniqueValue(baseId, new Set(customModes.map((mode) => mode.id))),
+      name: `${source.name} Copy`,
+      slash_command: uniqueValue(
+        baseCommand,
+        new Set(customModes.map((mode) => mode.slash_command)),
+      ),
+      enabled: false,
+    };
+    setModes([...customModes, copy]);
+    setActiveKey(`custom:${copy.id}`);
+  };
+  const deleteMode = (index: number) => {
+    setModes(customModes.filter((_, itemIndex) => itemIndex !== index));
+    setActiveKey("default");
+  };
 
   const tabItems = [
     {
-      key: "react",
+      key: "default",
       label: (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
-          <Repeat size={13} />
-          {t("agentConfig.reactModeTab", "Loop Template - Default")}
+        <span className={loopStyles.builtInTab}>
+          <Lock size={12} />
+          Default
         </span>
       ),
-      children: <ReactTab />,
+      children: <DefaultModeTab />,
     },
     {
       key: "goal",
       label: (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
-          <Target size={13} />
-          {t("agentConfig.goalModeTab", "Loop Template - Goal")}
+        <span className={loopStyles.builtInTab}>
+          <Lock size={12} />
+          Goal
         </span>
       ),
       children: <GoalModeTab />,
@@ -673,62 +1332,82 @@ export function AgentLoopCard() {
     {
       key: "mission",
       label: (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
-          <Rocket size={13} />
-          {t("agentConfig.missionModeTab", "Loop Template - Mission")}
+        <span className={loopStyles.builtInTab}>
+          <Lock size={12} />
+          Mission
         </span>
       ),
       children: <MissionModeTab />,
     },
-    {
-      key: "add",
-      label: (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 4,
-            color: "var(--text-quaternary, rgba(0,0,0,0.25))",
-          }}
-        >
-          <Plus size={13} />
-        </span>
-      ),
+    ...customModes.map((mode, index) => ({
+      key: `custom:${mode.id}`,
+      label: <span className={loopStyles.customTab}>{mode.name}</span>,
       children: (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "40px 0",
-            color: "var(--text-secondary, rgba(0,0,0,0.45))",
-          }}
-        >
-          <Plus size={32} style={{ opacity: 0.3, marginBottom: 12 }} />
-          <p style={{ fontSize: 14, fontWeight: 500 }}>
-            {t("agentConfig.customLoopTitle", "Custom Loop Modes")}
-          </p>
-          <p style={{ fontSize: 12 }}>
-            {t(
-              "agentConfig.customLoopDesc",
-              "Create your own loop modes with custom gate combinations. Coming soon.",
-            )}
-          </p>
-        </div>
+        <CustomModeEditor
+          modeIndex={index}
+          onDelete={() => deleteMode(index)}
+          onDuplicate={() => duplicateMode(index)}
+        />
       ),
-    },
+    })),
   ];
 
   return (
     <Card
-      className={styles.formCard}
+      className={`${styles.formCard} ${loopStyles.loopCard}`}
       title={t("agentConfig.agentLoopTitle", "Agent Loop Settings")}
     >
-      <Tabs defaultActiveKey="react" items={tabItems} size="small" />
+      <Tabs
+        activeKey={activeKey}
+        onChange={setActiveKey}
+        items={tabItems}
+        size="small"
+        tabBarExtraContent={
+          <Button
+            className={loopStyles.addModeButton}
+            icon={<Plus size={15} />}
+            onClick={() => setCreating(true)}
+            disabled={customModes.length >= 20}
+            aria-label="Create custom loop mode"
+          />
+        }
+      />
+      <Modal
+        title="Create custom loop mode"
+        open={creating}
+        onCancel={() => setCreating(false)}
+        onOk={createMode}
+        okButtonProps={{ disabled: !newName.trim() || !newCommand.trim() }}
+      >
+        <div className={loopStyles.createForm}>
+          <label>Display name</label>
+          <Input
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+          />
+          <label>Slash command</label>
+          <Input
+            prefix="/"
+            value={newCommand}
+            onChange={(event) =>
+              setNewCommand(
+                event.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""),
+              )
+            }
+          />
+          <label>Starting template</label>
+          <Select
+            value={template}
+            onChange={setTemplate}
+            options={[
+              { value: "safe", label: "Safe run" },
+              { value: "research", label: "Budgeted research" },
+              { value: "quality", label: "Quality first" },
+              { value: "blank", label: "Blank pipeline" },
+            ]}
+          />
+        </div>
+      </Modal>
     </Card>
   );
 }

--- a/src/qwenpaw/app/routers/loops.py
+++ b/src/qwenpaw/app/routers/loops.py
@@ -1,44 +1,212 @@
 # -*- coding: utf-8 -*-
-"""Loop management API — list available loops.
-
-Endpoints:
-    GET /api/loops — list all available loops
-"""
+"""Loop discovery, catalog, and custom mode persistence APIs."""
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request, status
+
+from ...config.config import CustomLoopModeConfig, save_agent_config
+from ...loop.catalog import get_gate_catalog
+from ...loop.compiler import compile_loop_mode
+from ..agent_context import get_agent_for_request
+from ..utils import schedule_agent_reload
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/loops", tags=["loops"])
 
-BUILTIN_LOOP = {
-    "name": "goal",
-    "slash_command": "goal",
-    "description": "Set a goal — agent works until done.",
-    "source": "builtin",
-}
+BUILTIN_LOOPS = [
+    {
+        "name": "default",
+        "slash_command": "",
+        "description": "The standard guarded agent loop.",
+        "source": "builtin",
+    },
+    {
+        "name": "goal",
+        "slash_command": "goal",
+        "description": "Set a goal and work until it is done.",
+        "source": "builtin",
+    },
+    {
+        "name": "mission",
+        "slash_command": "mission",
+        "description": "Run a persistent multi-step mission.",
+        "source": "builtin",
+    },
+]
 
 
 @router.get("")
-async def list_loops() -> list[dict[str, Any]]:
-    """List all available loops (builtin + plugin)."""
-    result: list[dict[str, Any]] = [BUILTIN_LOOP]
+async def list_loops(request: Request) -> list[dict[str, Any]]:
+    """List built-in, custom, and plugin-provided loops."""
+    result = [dict(item) for item in BUILTIN_LOOPS]
+    workspace = await get_agent_for_request(request)
+    for mode in workspace.config.running.loop.custom_modes:
+        if not mode.enabled:
+            continue
+        result.append(
+            {
+                "name": mode.name,
+                "slash_command": mode.slash_command,
+                "description": mode.description,
+                "source": "custom",
+                "id": mode.id,
+            },
+        )
+    result.extend(_list_plugin_loops())
+    return _deduplicate(result)
 
-    plugin_loops = _list_plugin_loops()
-    result.extend(plugin_loops)
 
+@router.get("/gates/catalog")
+async def list_gate_catalog() -> list[dict[str, Any]]:
+    """Return the explicit built-in gate catalog."""
+    return get_gate_catalog().describe()
+
+
+@router.get("/custom", response_model=list[CustomLoopModeConfig])
+async def list_custom_modes(request: Request) -> list[CustomLoopModeConfig]:
+    """Return every saved custom loop mode for the current agent."""
+    workspace = await get_agent_for_request(request)
+    return workspace.config.running.loop.custom_modes
+
+
+@router.post(
+    "/custom",
+    response_model=CustomLoopModeConfig,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_custom_mode(
+    request: Request,
+    mode: CustomLoopModeConfig,
+) -> CustomLoopModeConfig:
+    """Validate and append one complete custom mode."""
+    workspace = await get_agent_for_request(request)
+    modes = list(workspace.config.running.loop.custom_modes)
+    if any(item.id == mode.id for item in modes):
+        raise HTTPException(status_code=409, detail="Mode ID already exists")
+    _validate_mode(mode, workspace, modes)
+    modes.append(mode)
+    _persist_modes(request, workspace, modes)
+    return mode
+
+
+@router.put("/custom/{mode_id}", response_model=CustomLoopModeConfig)
+async def update_custom_mode(
+    request: Request,
+    mode_id: str,
+    mode: CustomLoopModeConfig,
+) -> CustomLoopModeConfig:
+    """Atomically replace one custom mode."""
+    if mode.id != mode_id:
+        raise HTTPException(status_code=422, detail="Mode ID cannot change")
+    workspace = await get_agent_for_request(request)
+    modes = list(workspace.config.running.loop.custom_modes)
+    index = _find_mode(modes, mode_id)
+    others = [item for item in modes if item.id != mode_id]
+    _validate_mode(mode, workspace, others, ignored_mode=modes[index])
+    modes[index] = mode
+    _persist_modes(request, workspace, modes)
+    return mode
+
+
+@router.delete("/custom/{mode_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_custom_mode(request: Request, mode_id: str) -> None:
+    """Delete one saved custom mode."""
+    workspace = await get_agent_for_request(request)
+    modes = list(workspace.config.running.loop.custom_modes)
+    index = _find_mode(modes, mode_id)
+    modes.pop(index)
+    _persist_modes(request, workspace, modes)
+
+
+@router.post(
+    "/custom/{mode_id}/duplicate",
+    response_model=CustomLoopModeConfig,
+    status_code=status.HTTP_201_CREATED,
+)
+async def duplicate_custom_mode(
+    request: Request,
+    mode_id: str,
+) -> CustomLoopModeConfig:
+    """Create a disabled copy with unique identity and command."""
+    workspace = await get_agent_for_request(request)
+    modes = list(workspace.config.running.loop.custom_modes)
+    source = modes[_find_mode(modes, mode_id)]
+    copy = deepcopy(source)
+    copy.id = _unique_value(f"{source.id}-copy", {item.id for item in modes})
+    copy.name = f"{source.name} Copy"
+    copy.slash_command = _unique_value(
+        f"{source.slash_command}-copy",
+        {item.slash_command for item in modes},
+    )
+    copy.enabled = False
+    modes.append(copy)
+    _persist_modes(request, workspace, modes)
+    return copy
+
+
+def _validate_mode(
+    mode: CustomLoopModeConfig,
+    workspace: Any,
+    other_modes: list[CustomLoopModeConfig],
+    ignored_mode: CustomLoopModeConfig | None = None,
+) -> None:
+    """Validate catalog data and command collisions."""
+    try:
+        compile_loop_mode(mode)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if any(item.slash_command == mode.slash_command for item in other_modes):
+        raise HTTPException(status_code=409, detail="Slash command exists")
+    registered = set(workspace.plugins.slash_command_registry.names())
+    if ignored_mode is not None:
+        registered.discard(ignored_mode.slash_command)
+    if mode.slash_command in registered:
+        raise HTTPException(status_code=409, detail="Slash command exists")
+
+
+def _persist_modes(
+    request: Request,
+    workspace: Any,
+    modes: list[CustomLoopModeConfig],
+) -> None:
+    """Persist modes and schedule a safe workspace reload."""
+    config = workspace.config
+    config.running.loop.custom_modes = modes
+    save_agent_config(workspace.agent_id, config)
+    schedule_agent_reload(request, workspace.agent_id)
+
+
+def _find_mode(modes: list[CustomLoopModeConfig], mode_id: str) -> int:
+    for index, mode in enumerate(modes):
+        if mode.id == mode_id:
+            return index
+    raise HTTPException(status_code=404, detail="Custom mode not found")
+
+
+def _unique_value(base: str, existing: set[str]) -> str:
+    candidate = base
+    suffix = 2
+    while candidate in existing:
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def _deduplicate(loops: list[dict[str, Any]]) -> list[dict[str, Any]]:
     seen: set[str] = set()
-    deduped: list[dict[str, Any]] = []
-    for loop in result:
-        key = loop.get("slash_command", loop["name"])
+    result: list[dict[str, Any]] = []
+    for loop in loops:
+        key = str(loop.get("slash_command") or loop["name"])
         if key not in seen:
             seen.add(key)
-            deduped.append(loop)
-    return deduped
+            result.append(loop)
+    return result
 
 
 def _list_plugin_loops() -> list[dict[str, Any]]:
@@ -47,41 +215,28 @@ def _list_plugin_loops() -> list[dict[str, Any]]:
     try:
         from ...plugins.registry import PluginRegistry
 
-        mgr = PluginRegistry().get_workspace_manager()
-        if mgr is None:
+        manager = PluginRegistry().get_workspace_manager()
+        if manager is None:
             return result
-        for ws in getattr(
-            mgr,
-            "workspaces",
-            {},
-        ).values():
-            plugins = getattr(ws, "plugins", None)
-            if plugins is None:
-                continue
-            for h in getattr(
-                plugins,
-                "stop_handlers",
-                [],
-            ):
-                meta = getattr(h, "metadata", {})
-                if meta.get("loop_name"):
+        for workspace in getattr(manager, "workspaces", {}).values():
+            plugins = getattr(workspace, "plugins", None)
+            for registration in getattr(plugins, "stop_handlers", []):
+                metadata = getattr(registration, "metadata", {})
+                if metadata.get("loop_name"):
                     result.append(
                         {
-                            "name": meta["loop_name"],
-                            "slash_command": meta.get(
+                            "name": metadata["loop_name"],
+                            "slash_command": metadata.get(
                                 "slash_command",
-                                meta["loop_name"],
+                                metadata["loop_name"],
                             ),
-                            "description": meta.get(
-                                "description",
-                                "",
-                            ),
+                            "description": metadata.get("description", ""),
                             "source": "plugin",
                         },
                     )
-    except Exception as exc:
-        logger.warning(
-            "Failed to list plugin loops: %s",
-            exc,
-        )
+    except Exception:
+        logger.warning("Failed to list plugin loops", exc_info=True)
     return result
+
+
+__all__ = ["router"]

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -225,6 +225,16 @@ class Workspace:
                         exc_info=True,
                     )
 
+        try:
+            from ...modes.custom_loop import load_custom_loop_modes
+
+            load_custom_loop_modes(self)
+        except Exception:
+            logger.warning(
+                "bootstrap: custom loop modes could not be loaded",
+                exc_info=True,
+            )
+
         # pylint: disable=protected-access
         n_hooks = len(self.plugins.hook_registry._by_phase)
         n_cmds = len(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1164,6 +1164,83 @@ class RubricGateConfig(BaseModel):
     )
 
 
+class GateInstanceConfig(BaseModel):
+    """One built-in gate configured in a custom loop mode."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_-]*$",
+    )
+    type: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_]*$",
+    )
+    enabled: bool = True
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CustomLoopModeConfig(BaseModel):
+    """A saved custom loop mode made from built-in gates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_-]*$",
+    )
+    name: str = Field(min_length=1, max_length=80)
+    description: str = Field(default="", max_length=500)
+    slash_command: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_-]*$",
+    )
+    enabled: bool = False
+    gates: List[GateInstanceConfig] = Field(
+        default_factory=list,
+        max_length=20,
+    )
+
+    @model_validator(mode="after")
+    def validate_pipeline(self) -> "CustomLoopModeConfig":
+        """Reject ambiguous or unsafe pipeline shapes."""
+        gate_ids = [gate.id for gate in self.gates]
+        if len(gate_ids) != len(set(gate_ids)):
+            raise ValueError("Gate instance IDs must be unique")
+
+        gate_types = [gate.type for gate in self.gates if gate.enabled]
+        if len(gate_types) != len(set(gate_types)):
+            raise ValueError("Gate types cannot be repeated")
+        if {
+            "completion_rubric",
+            "text_response_retry",
+        }.issubset(gate_types):
+            raise ValueError(
+                "Completion rubric conflicts with text response retry",
+            )
+        if self.enabled and not gate_types:
+            raise ValueError("Enabled custom modes require an enabled gate")
+        return self
+
+
+class GoalLoopModeConfig(BaseModel):
+    """Editable values for the fixed built-in Goal pipeline."""
+
+    max_iterations: int = Field(default=20, ge=1, le=500)
+    max_tokens: int = Field(default=300_000, ge=1)
+
+
+class MissionLoopModeConfig(BaseModel):
+    """Editable values for the fixed built-in Mission pipeline."""
+
+    max_iterations: int = Field(default=20, ge=1, le=100)
+
+
 class LoopConfig(BaseModel):
     """Loop engineering configuration."""
 
@@ -1179,6 +1256,37 @@ class LoopConfig(BaseModel):
         default_factory=RubricGateConfig,
         description="Completion check settings",
     )
+    goal: GoalLoopModeConfig = Field(
+        default_factory=GoalLoopModeConfig,
+        description="Fixed Goal mode gate values",
+    )
+    mission: MissionLoopModeConfig = Field(
+        default_factory=MissionLoopModeConfig,
+        description="Fixed Mission mode gate values",
+    )
+    custom_modes: List[CustomLoopModeConfig] = Field(
+        default_factory=list,
+        max_length=20,
+        description="User-defined loop modes built from built-in gates",
+    )
+
+    @model_validator(mode="after")
+    def validate_custom_modes(self) -> "LoopConfig":
+        """Keep custom mode identity and commands unambiguous."""
+        mode_ids = [mode.id for mode in self.custom_modes]
+        if len(mode_ids) != len(set(mode_ids)):
+            raise ValueError("Custom loop mode IDs must be unique")
+        commands = [mode.slash_command for mode in self.custom_modes]
+        if len(commands) != len(set(commands)):
+            raise ValueError("Custom loop slash commands must be unique")
+
+        from ..loop.catalog import get_gate_catalog
+
+        catalog = get_gate_catalog()
+        for mode in self.custom_modes:
+            for gate in mode.gates:
+                catalog.validate_params(gate.type, gate.params)
+        return self
 
 
 class AgentsRunningConfig(BaseModel):

--- a/src/qwenpaw/loop/catalog.py
+++ b/src/qwenpaw/loop/catalog.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+"""Built-in gate catalog for user-editable loop modes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Type
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..config.config import DoomLoopConfig, DoomLoopStageConfig
+from .gates.base import StopGate
+from .gates.completion import CompletionRubricGate
+from .gates.doom_loop import DoomLoopGate
+from .gates.iteration import IterationGate
+from .gates.limits import TimeoutGate, TokenBudgetGate, ToolCallBudgetGate
+from .gates.rubric import StandaloneRubricGate
+
+
+class _Params(BaseModel):
+    """Strict base for gate construction parameters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class IterationParams(_Params):
+    """Iteration gate parameters."""
+
+    max_iterations: int = Field(default=40, ge=1, le=500)
+
+
+class DoomLoopParams(_Params):
+    """Repetition protection parameters."""
+
+    window_size: int = Field(default=3, ge=2, le=20)
+    similarity_threshold: float = Field(default=1.0, ge=0.0, le=1.0)
+    stages: list[DoomLoopStageConfig] = Field(
+        default_factory=lambda: DoomLoopConfig().stages,
+    )
+
+
+class TokenBudgetParams(_Params):
+    """Token budget parameters."""
+
+    max_total_tokens: int | None = Field(default=120_000, ge=1)
+    max_prompt_tokens: int | None = Field(default=None, ge=1)
+    max_completion_tokens: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def require_limit(self) -> "TokenBudgetParams":
+        """Require at least one effective token limit."""
+        if not any(
+            (
+                self.max_total_tokens,
+                self.max_prompt_tokens,
+                self.max_completion_tokens,
+            ),
+        ):
+            raise ValueError("At least one token limit is required")
+        return self
+
+
+class TimeoutParams(_Params):
+    """Wall-clock boundary parameters."""
+
+    max_seconds: float = Field(default=1800.0, ge=1.0, le=86400.0)
+
+
+class ToolCallBudgetParams(_Params):
+    """Global and per-tool call limits."""
+
+    max_calls: int | None = Field(default=30, ge=1, le=10000)
+    per_tool: dict[str, int] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_limits(self) -> "ToolCallBudgetParams":
+        """Reject empty and non-positive tool limits."""
+        if self.max_calls is None and not self.per_tool:
+            raise ValueError("At least one tool call limit is required")
+        if any(not name or limit < 1 for name, limit in self.per_tool.items()):
+            raise ValueError(
+                "Per-tool limits require names and positive values",
+            )
+        return self
+
+
+class TextResponseRetryParams(_Params):
+    """Text-only response retry parameters."""
+
+    prompt: str = Field(
+        default=("Verify the task before stopping. Continue if work remains."),
+        min_length=1,
+        max_length=8192,
+    )
+    max_interventions: int = Field(default=1, ge=1, le=10)
+
+
+class RubricCriterionParams(_Params):
+    """One completion rubric criterion."""
+
+    id: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_-]*$",
+    )
+    description: str = Field(min_length=1, max_length=1000)
+    required: bool = True
+    weight: float = Field(default=1.0, gt=0.0, le=100.0)
+
+
+class CompletionRubricParams(_Params):
+    """Structured completion evaluator parameters."""
+
+    criteria: list[RubricCriterionParams] = Field(
+        min_length=1,
+        max_length=20,
+    )
+    pass_threshold: float = Field(default=1.0, ge=0.0, le=1.0)
+    max_revisions: int = Field(default=2, ge=0, le=10)
+    evaluate_when: Literal["text_response"] = "text_response"
+    include_last_tool_results: int = Field(default=5, ge=0, le=20)
+    on_grader_error: Literal["stop", "continue_once"] = "stop"
+
+    @model_validator(mode="after")
+    def unique_criteria(self) -> "CompletionRubricParams":
+        """Require stable unique criterion IDs."""
+        ids = [criterion.id for criterion in self.criteria]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Rubric criterion IDs must be unique")
+        return self
+
+
+@dataclass(frozen=True)
+class GateCatalogEntry:
+    """One QwenPaw-owned gate available to custom modes."""
+
+    type: str
+    title: str
+    description: str
+    category: str
+    params_model: Type[BaseModel]
+    factory: Callable[[BaseModel], StopGate]
+    cost: Literal["none", "model_call"] = "none"
+    conflicts_with: tuple[str, ...] = ()
+
+    def describe(self) -> dict[str, Any]:
+        """Return stable frontend metadata and JSON Schema."""
+        return {
+            "type": self.type,
+            "title": self.title,
+            "description": self.description,
+            "category": self.category,
+            "schema": self.params_model.model_json_schema(),
+            "cost": self.cost,
+            "conflicts_with": list(self.conflicts_with),
+        }
+
+
+class GateCatalog:
+    """Explicit whitelist of built-in user-configurable gates."""
+
+    def __init__(self, entries: list[GateCatalogEntry]) -> None:
+        self._entries = {entry.type: entry for entry in entries}
+
+    def describe(self) -> list[dict[str, Any]]:
+        """List entries in registration order."""
+        return [entry.describe() for entry in self._entries.values()]
+
+    def validate_params(self, gate_type: str, params: dict) -> BaseModel:
+        """Validate parameters for one catalog type."""
+        entry = self._entry(gate_type)
+        return entry.params_model.model_validate(params)
+
+    def create(self, gate_type: str, params: dict) -> StopGate:
+        """Construct one built-in gate from validated data."""
+        entry = self._entry(gate_type)
+        validated = entry.params_model.model_validate(params)
+        return entry.factory(validated)
+
+    def conflicts(self, gate_type: str) -> tuple[str, ...]:
+        """Return incompatible gate types."""
+        return self._entry(gate_type).conflicts_with
+
+    def _entry(self, gate_type: str) -> GateCatalogEntry:
+        try:
+            return self._entries[gate_type]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown built-in gate type: {gate_type}",
+            ) from exc
+
+
+def _dump(params: BaseModel) -> dict[str, Any]:
+    return params.model_dump()
+
+
+def _completion_gate(params: BaseModel) -> StopGate:
+    """Construct the evaluator without UI-only trigger metadata."""
+    values = params.model_dump()
+    values.pop("evaluate_when", None)
+    return CompletionRubricGate(**values)
+
+
+def _entries() -> list[GateCatalogEntry]:
+    """Build the immutable catalog declaration."""
+    return [
+        GateCatalogEntry(
+            type="iteration",
+            title="Iteration limit",
+            description="Stop after a fixed number of loop iterations.",
+            category="limits",
+            params_model=IterationParams,
+            factory=lambda params: IterationGate(**_dump(params)),
+        ),
+        GateCatalogEntry(
+            type="doom_loop",
+            title="Repetition protection",
+            description="Detect repeated tool calls and change strategy.",
+            category="safety",
+            params_model=DoomLoopParams,
+            factory=lambda params: DoomLoopGate(**_dump(params)),
+        ),
+        GateCatalogEntry(
+            type="token_budget",
+            title="Token budget",
+            description="Limit prompt and completion token usage.",
+            category="limits",
+            params_model=TokenBudgetParams,
+            factory=lambda params: TokenBudgetGate(**_dump(params)),
+        ),
+        GateCatalogEntry(
+            type="timeout",
+            title="Time limit",
+            description="Stop at a loop boundary after elapsed time.",
+            category="limits",
+            params_model=TimeoutParams,
+            factory=lambda params: TimeoutGate(**_dump(params)),
+        ),
+        GateCatalogEntry(
+            type="tool_call_budget",
+            title="Tool-call budget",
+            description="Limit all calls and selected tools.",
+            category="limits",
+            params_model=ToolCallBudgetParams,
+            factory=lambda params: ToolCallBudgetGate(**_dump(params)),
+        ),
+        GateCatalogEntry(
+            type="text_response_retry",
+            title="Early-stop retry",
+            description="Prompt the agent to verify before ending.",
+            category="behavior",
+            params_model=TextResponseRetryParams,
+            factory=lambda params: StandaloneRubricGate(**_dump(params)),
+            conflicts_with=("completion_rubric",),
+        ),
+        GateCatalogEntry(
+            type="completion_rubric",
+            title="Completion rubric",
+            description="Evaluate explicit completion criteria.",
+            category="quality",
+            params_model=CompletionRubricParams,
+            factory=_completion_gate,
+            cost="model_call",
+            conflicts_with=("text_response_retry",),
+        ),
+    ]
+
+
+_CATALOG = GateCatalog(_entries())
+
+
+def get_gate_catalog() -> GateCatalog:
+    """Return the process-wide immutable built-in catalog."""
+    return _CATALOG
+
+
+__all__ = [
+    "CompletionRubricParams",
+    "DoomLoopParams",
+    "GateCatalog",
+    "GateCatalogEntry",
+    "IterationParams",
+    "TextResponseRetryParams",
+    "TimeoutParams",
+    "TokenBudgetParams",
+    "ToolCallBudgetParams",
+    "get_gate_catalog",
+]

--- a/src/qwenpaw/loop/compiler.py
+++ b/src/qwenpaw/loop/compiler.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Compile declarative custom loop modes into stop handlers."""
+from __future__ import annotations
+
+from ..config.config import CustomLoopModeConfig
+from .catalog import GateCatalog, get_gate_catalog
+from .gates.configured import ConfiguredGate
+from .gates.handler import StopHandler
+
+
+def compile_loop_mode(
+    config: CustomLoopModeConfig,
+    catalog: GateCatalog | None = None,
+) -> StopHandler:
+    """Compile one complete mode atomically."""
+    gate_catalog = catalog or get_gate_catalog()
+    for gate in config.gates:
+        gate_catalog.validate_params(gate.type, gate.params)
+
+    enabled = [gate for gate in config.gates if gate.enabled]
+    types = {gate.type for gate in enabled}
+    for gate_type in types:
+        conflicts = set(gate_catalog.conflicts(gate_type))
+        overlap = conflicts.intersection(types)
+        if overlap:
+            names = ", ".join(sorted(overlap))
+            raise ValueError(f"Gate '{gate_type}' conflicts with {names}")
+
+    configured: list[ConfiguredGate] = []
+    for index, gate_config in enumerate(enabled):
+        gate = gate_catalog.create(
+            gate_config.type,
+            gate_config.params,
+        )
+        configured.append(
+            ConfiguredGate(
+                instance_id=gate_config.id,
+                order=index * 10,
+                gate=gate,
+            ),
+        )
+
+    handler = StopHandler()
+    handler.replace(configured)
+    return handler
+
+
+__all__ = ["compile_loop_mode"]

--- a/src/qwenpaw/loop/gates/__init__.py
+++ b/src/qwenpaw/loop/gates/__init__.py
@@ -15,10 +15,13 @@ from .base import (
     StopHandlerResult,
 )
 from .budget import BudgetGate
+from .completion import CompletionRubricGate
+from .configured import ConfiguredGate
 from .doom_loop import DoomLoopGate
 from .file_loop_gate import FileLoopGate
 from .handler import StopHandler
 from .iteration import IterationGate
+from .limits import TimeoutGate, TokenBudgetGate, ToolCallBudgetGate
 from .runner import run_stop_handlers
 from .loop_gate import LoopGate
 from .rubric import (
@@ -33,6 +36,8 @@ from .rubric import (
 
 __all__ = [
     "BudgetGate",
+    "CompletionRubricGate",
+    "ConfiguredGate",
     "StandaloneRubricGate",
     "DefaultRubric",
     "DoomLoopGate",
@@ -49,5 +54,8 @@ __all__ = [
     "StopHandlerRegistration",
     "StopHandlerResult",
     "SubAgentRubric",
+    "TimeoutGate",
+    "TokenBudgetGate",
+    "ToolCallBudgetGate",
     "run_stop_handlers",
 ]

--- a/src/qwenpaw/loop/gates/completion.py
+++ b/src/qwenpaw/loop/gates/completion.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+"""Structured completion rubric gate."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from agentscope.message import Msg, TextBlock
+from pydantic import BaseModel, Field
+
+from .base import StopAction, StopHandlerResult
+from .loop_gate import LoopGate
+
+
+class RubricCriterionResult(BaseModel):
+    """One structured evaluator result."""
+
+    id: str
+    passed: bool
+    score: float = Field(ge=0.0, le=1.0)
+    evidence: list[str] = Field(default_factory=list)
+    feedback: str = ""
+
+
+class CompletionRubricResult(BaseModel):
+    """Structured result returned by the evaluator model."""
+
+    criteria: list[RubricCriterionResult]
+    feedback: str = ""
+
+
+@dataclass
+class _CompletionState:
+    """Per-turn completion evaluation state."""
+
+    revisions: int = 0
+    grader_errors: int = 0
+    continuation: str = ""
+
+
+class CompletionRubricGate(LoopGate):
+    """Evaluate completion criteria and request bounded revisions."""
+
+    def __init__(
+        self,
+        *,
+        criteria: list[dict[str, Any]],
+        pass_threshold: float = 1.0,
+        max_revisions: int = 2,
+        include_last_tool_results: int = 5,
+        on_grader_error: Literal["stop", "continue_once"] = "stop",
+    ) -> None:
+        super().__init__()
+        self._criteria = criteria
+        self._pass_threshold = pass_threshold
+        self._max_revisions = max_revisions
+        self._evidence_limit = include_last_tool_results
+        self._on_grader_error = on_grader_error
+
+    @property
+    def name(self) -> str:
+        return "completion-rubric"
+
+    @property
+    def priority(self) -> int:
+        return 90
+
+    def reset_turn(self) -> None:
+        """Reset revisions for a new user turn."""
+        self.activate(_CompletionState())
+
+    async def check(self, ctx: Any) -> StopHandlerResult:
+        """Evaluate text-only completion candidates."""
+        if ctx.get("has_tool_calls") or ctx.get("final_msg") is None:
+            return StopHandlerResult(action=StopAction.BYPASS)
+
+        state = self._state()
+        if state is None:
+            state = _CompletionState()
+            self.activate(state)
+
+        try:
+            result = await self._evaluate(ctx)
+        except Exception as exc:  # noqa: BLE001
+            return self._handle_grader_error(state, exc)
+
+        passed, score, feedback = self._score(result)
+        if passed:
+            return StopHandlerResult(
+                action=StopAction.TERMINATE,
+                reason=f"Completion rubric passed ({score:.0%})",
+            )
+
+        if state.revisions >= self._max_revisions:
+            return StopHandlerResult(
+                action=StopAction.TERMINATE,
+                reason=(
+                    f"Completion rubric stopped after "
+                    f"{self._max_revisions} revisions: {feedback}"
+                ),
+            )
+
+        state.revisions += 1
+        state.continuation = (
+            f"The completion check found remaining work. "
+            f"Address only these unmet criteria, then verify again:\n"
+            f"{feedback}"
+        )
+        return StopHandlerResult(
+            action=StopAction.INTERRUPT_AND_CONTINUE,
+            reason=f"Completion rubric requested revision {state.revisions}",
+            reset_peers=True,
+        )
+
+    def build_continuation(self) -> str:
+        """Return the latest bounded evaluator feedback."""
+        state = self._state()
+        return state.continuation if state is not None else ""
+
+    async def _evaluate(self, ctx: Any) -> CompletionRubricResult:
+        """Call the current model through its structured-output API."""
+        agent = ctx.get("agent")
+        model = getattr(agent, "model", None)
+        if model is None:
+            raise RuntimeError("Agent model is unavailable for evaluation")
+
+        final_text = self._message_text(ctx.get("final_msg"))
+        evidence = self._tool_evidence(agent)
+        goal = self._user_goal(agent)
+        payload = {
+            "user_goal": goal,
+            "criteria": self._criteria,
+            "candidate_response": final_text,
+            "observable_tool_evidence": evidence,
+        }
+        system_text = (
+            "Evaluate only the supplied completion criteria. Use observable "
+            "evidence, not claims of completion. Return one result per "
+            "criterion. Do not include hidden reasoning."
+        )
+        user_text = (
+            f"Evaluate this completion candidate:\n{json.dumps(payload)}"
+        )
+        response = await model.generate_structured_output(
+            messages=[
+                Msg(
+                    name="system",
+                    role="system",
+                    content=[TextBlock(type="text", text=system_text)],
+                ),
+                Msg(
+                    name="user",
+                    role="user",
+                    content=[TextBlock(type="text", text=user_text)],
+                ),
+            ],
+            structured_model=CompletionRubricResult,
+        )
+        return CompletionRubricResult.model_validate(response.content)
+
+    def _score(
+        self,
+        result: CompletionRubricResult,
+    ) -> tuple[bool, float, str]:
+        """Apply required and weighted criterion semantics."""
+        by_id = {item.id: item for item in result.criteria}
+        weighted_score = 0.0
+        total_weight = 0.0
+        unmet: list[str] = []
+        required_failed = False
+        for criterion in self._criteria:
+            criterion_id = str(criterion["id"])
+            item = by_id.get(criterion_id)
+            weight = float(criterion.get("weight", 1.0))
+            total_weight += weight
+            if item is not None:
+                weighted_score += item.score * weight
+            if item is None or not item.passed:
+                if criterion.get("required", True):
+                    required_failed = True
+                detail = item.feedback if item is not None else "Not evaluated"
+                unmet.append(f"- {criterion['description']}: {detail}")
+
+        score = weighted_score / total_weight if total_weight else 0.0
+        passed = not required_failed and score >= self._pass_threshold
+        feedback = "\n".join(unmet) or result.feedback
+        return passed, score, feedback
+
+    def _handle_grader_error(
+        self,
+        state: _CompletionState,
+        exc: Exception,
+    ) -> StopHandlerResult:
+        """Apply the configured fail-closed grader error policy."""
+        if (
+            self._on_grader_error == "continue_once"
+            and not state.grader_errors
+        ):
+            state.grader_errors += 1
+            state.continuation = (
+                "The completion evaluator was unavailable. Verify the "
+                "deliverable once more before stopping."
+            )
+            return StopHandlerResult(
+                action=StopAction.INTERRUPT_AND_CONTINUE,
+                reason=f"Completion evaluator error: {exc}",
+                reset_peers=True,
+            )
+        return StopHandlerResult(
+            action=StopAction.TERMINATE,
+            reason=f"Completion evaluator error: {exc}",
+        )
+
+    @staticmethod
+    def _message_text(message: Any) -> str:
+        """Extract text blocks from one message."""
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            return content
+        texts: list[str] = []
+        for block in content or []:
+            block_type = (
+                block.get("type")
+                if isinstance(block, dict)
+                else getattr(block, "type", None)
+            )
+            if block_type == "text":
+                text = (
+                    block.get("text", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", "")
+                )
+                if text:
+                    texts.append(str(text))
+        return "\n".join(texts)
+
+    def _tool_evidence(self, agent: Any) -> list[str]:
+        """Collect recent observable tool result text."""
+        evidence: list[str] = []
+        context = getattr(getattr(agent, "state", None), "context", [])
+        for message in reversed(context):
+            content = getattr(message, "content", None)
+            for block in content if isinstance(content, list) else []:
+                block_type = (
+                    block.get("type")
+                    if isinstance(block, dict)
+                    else getattr(block, "type", None)
+                )
+                if block_type not in ("tool_result", "tool_output"):
+                    continue
+                evidence.append(str(block)[:2000])
+                if len(evidence) >= self._evidence_limit:
+                    return evidence
+        return evidence
+
+    def _user_goal(self, agent: Any) -> str:
+        """Find the latest non-empty user message in agent context."""
+        context = getattr(getattr(agent, "state", None), "context", [])
+        for message in reversed(context):
+            if getattr(message, "role", None) != "user":
+                continue
+            text = self._message_text(message)
+            if text:
+                return text
+        return ""
+
+
+__all__ = [
+    "CompletionRubricGate",
+    "CompletionRubricResult",
+    "RubricCriterionResult",
+]

--- a/src/qwenpaw/loop/gates/configured.py
+++ b/src/qwenpaw/loop/gates/configured.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Order adapter for gates in declarative loop modes."""
+from __future__ import annotations
+
+from typing import Any
+
+from .base import StopGate, StopHandlerResult
+
+
+class ConfiguredGate(StopGate):
+    """Bind one built-in gate to user-defined identity and order."""
+
+    def __init__(
+        self,
+        *,
+        instance_id: str,
+        order: int,
+        gate: StopGate,
+    ) -> None:
+        self._instance_id = instance_id
+        self._order = order
+        self._gate = gate
+
+    @property
+    def name(self) -> str:
+        return self._instance_id
+
+    @property
+    def priority(self) -> int:
+        return self._order
+
+    async def check(self, ctx: Any) -> StopHandlerResult | None:
+        """Delegate evaluation to the configured gate."""
+        return await self._gate.check(ctx)
+
+    def build_continuation(self) -> str:
+        """Delegate continuation construction."""
+        return self._gate.build_continuation()
+
+    def reset_turn(self) -> None:
+        """Delegate turn reset."""
+        self._gate.reset_turn()
+
+    def reset_session(self) -> None:
+        """Delegate session reset."""
+        self._gate.reset_session()
+
+
+__all__ = ["ConfiguredGate"]

--- a/src/qwenpaw/loop/gates/limits.py
+++ b/src/qwenpaw/loop/gates/limits.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""Built-in resource limit gates for custom loop modes."""
+from __future__ import annotations
+
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import StopAction, StopHandlerResult
+from .loop_gate import LoopGate
+
+
+def _bypass() -> StopHandlerResult:
+    """Return a gate bypass result."""
+    return StopHandlerResult(action=StopAction.BYPASS)
+
+
+@dataclass
+class _TokenBudgetState:
+    """Per-turn accumulated model usage."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    last_iteration: int = -1
+
+
+class TokenBudgetGate(LoopGate):
+    """Stop a loop when configured token limits are reached."""
+
+    def __init__(
+        self,
+        *,
+        max_total_tokens: int | None = None,
+        max_prompt_tokens: int | None = None,
+        max_completion_tokens: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._max_total = max_total_tokens
+        self._max_prompt = max_prompt_tokens
+        self._max_completion = max_completion_tokens
+
+    @property
+    def name(self) -> str:
+        return "token-budget"
+
+    @property
+    def priority(self) -> int:
+        return 20
+
+    def reset_turn(self) -> None:
+        """Start a fresh per-turn usage accumulator."""
+        self.activate(_TokenBudgetState())
+
+    async def check(self, ctx: Any) -> StopHandlerResult:
+        """Record the latest model usage and enforce every limit."""
+        state = self._state()
+        if state is None:
+            state = _TokenBudgetState()
+            self.activate(state)
+
+        iteration = int(ctx.get("iteration", 0))
+        if state.last_iteration != iteration:
+            usage = self._current_usage()
+            state.prompt_tokens += int(usage.get("prompt_tokens", 0))
+            state.completion_tokens += int(
+                usage.get("completion_tokens", 0),
+            )
+            state.last_iteration = iteration
+
+        total = state.prompt_tokens + state.completion_tokens
+        exceeded = (
+            self._reached(total, self._max_total)
+            or self._reached(state.prompt_tokens, self._max_prompt)
+            or self._reached(
+                state.completion_tokens,
+                self._max_completion,
+            )
+        )
+        if not exceeded:
+            return _bypass()
+        return StopHandlerResult(
+            action=StopAction.TERMINATE,
+            reason=f"Token budget reached ({total} tokens used)",
+        )
+
+    @staticmethod
+    def _reached(value: int, limit: int | None) -> bool:
+        return limit is not None and value >= limit
+
+    @staticmethod
+    def _current_usage() -> dict[str, Any]:
+        """Read usage recorded for the current session."""
+        from ...app.agent_context import get_current_session_id
+        from ...token_usage.model_wrapper import TokenRecordingModelWrapper
+
+        session_id = get_current_session_id()
+        if not session_id:
+            return {}
+        # pylint: disable=protected-access
+        return TokenRecordingModelWrapper._usage_by_session.get(
+            session_id,
+            {},
+        )
+
+
+@dataclass
+class _TimeoutState:
+    """Monotonic start time for one turn."""
+
+    started_at: float = field(default_factory=time.monotonic)
+
+
+class TimeoutGate(LoopGate):
+    """Stop at a loop boundary after a monotonic timeout."""
+
+    def __init__(self, max_seconds: float) -> None:
+        super().__init__()
+        self._max_seconds = max_seconds
+
+    @property
+    def name(self) -> str:
+        return "timeout"
+
+    @property
+    def priority(self) -> int:
+        return 30
+
+    def reset_turn(self) -> None:
+        """Reset elapsed time for a new user turn."""
+        self.activate(_TimeoutState())
+
+    async def check(self, ctx: Any) -> StopHandlerResult:  # noqa: ARG002
+        """Terminate after the configured elapsed duration."""
+        state = self._state()
+        if state is None:
+            state = _TimeoutState()
+            self.activate(state)
+        elapsed = time.monotonic() - state.started_at
+        if elapsed < self._max_seconds:
+            return _bypass()
+        return StopHandlerResult(
+            action=StopAction.TERMINATE,
+            reason=f"Loop time limit reached ({self._max_seconds:g}s)",
+        )
+
+
+@dataclass
+class _ToolCallBudgetState:
+    """Tool call counts observed during one turn."""
+
+    total: int = 0
+    by_tool: Counter[str] = field(default_factory=Counter)
+    last_iteration: int = -1
+
+
+class ToolCallBudgetGate(LoopGate):
+    """Limit total and per-tool calls in one agent turn."""
+
+    def __init__(
+        self,
+        *,
+        max_calls: int | None = None,
+        per_tool: dict[str, int] | None = None,
+    ) -> None:
+        super().__init__()
+        self._max_calls = max_calls
+        self._per_tool = per_tool or {}
+
+    @property
+    def name(self) -> str:
+        return "tool-call-budget"
+
+    @property
+    def priority(self) -> int:
+        return 40
+
+    def reset_turn(self) -> None:
+        """Reset tool call counters for a new turn."""
+        self.activate(_ToolCallBudgetState())
+
+    async def check(self, ctx: Any) -> StopHandlerResult:
+        """Count the latest iteration's calls and enforce limits."""
+        state = self._state()
+        if state is None:
+            state = _ToolCallBudgetState()
+            self.activate(state)
+        iteration = int(ctx.get("iteration", 0))
+        if iteration != state.last_iteration:
+            names = self._latest_tool_names(ctx.get("agent"))
+            state.total += len(names)
+            state.by_tool.update(names)
+            state.last_iteration = iteration
+
+        if self._max_calls is not None and state.total >= self._max_calls:
+            return StopHandlerResult(
+                action=StopAction.TERMINATE,
+                reason=f"Tool call budget reached ({state.total} calls)",
+            )
+        for name, limit in self._per_tool.items():
+            if state.by_tool[name] >= limit:
+                return StopHandlerResult(
+                    action=StopAction.TERMINATE,
+                    reason=f"Tool '{name}' call budget reached ({limit})",
+                )
+        return _bypass()
+
+    @staticmethod
+    def _latest_tool_names(agent: Any) -> list[str]:
+        """Extract tool names from the latest context message with calls."""
+        context = getattr(getattr(agent, "state", None), "context", [])
+        for message in reversed(context):
+            names: list[str] = []
+            content = getattr(message, "content", None)
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                block_type = (
+                    block.get("type")
+                    if isinstance(block, dict)
+                    else getattr(block, "type", None)
+                )
+                if block_type not in ("tool_call", "tool_use"):
+                    continue
+                name = (
+                    block.get("name", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "name", "")
+                )
+                if name:
+                    names.append(str(name))
+            if names:
+                return names
+        return []
+
+
+__all__ = [
+    "TimeoutGate",
+    "TokenBudgetGate",
+    "ToolCallBudgetGate",
+]

--- a/src/qwenpaw/modes/custom_loop/__init__.py
+++ b/src/qwenpaw/modes/custom_loop/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Public exports for declarative custom loop modes."""
+
+from .loader import load_custom_loop_modes
+from .mode import (
+    CustomLoopController,
+    DeclarativeLoopMode,
+    LoopModeActivationStore,
+)
+
+__all__ = [
+    "CustomLoopController",
+    "DeclarativeLoopMode",
+    "LoopModeActivationStore",
+    "load_custom_loop_modes",
+]

--- a/src/qwenpaw/modes/custom_loop/loader.py
+++ b/src/qwenpaw/modes/custom_loop/loader.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Load saved custom loop modes into one workspace."""
+from __future__ import annotations
+
+import logging
+
+from .mode import (
+    CustomLoopController,
+    DeclarativeLoopMode,
+    LoopModeActivationStore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def load_custom_loop_modes(workspace: object) -> None:
+    """Compile and register every enabled, conflict-free custom mode."""
+    configs = workspace.config.running.loop.custom_modes
+    enabled = [config for config in configs if config.enabled]
+    if not enabled:
+        return
+
+    registry = workspace.plugins.slash_command_registry
+    reserved = set(registry.names())
+    store = LoopModeActivationStore()
+    loaded = 0
+    for config in enabled:
+        if config.slash_command in reserved:
+            logger.warning(
+                "Custom loop mode '%s' skipped: /%s already exists",
+                config.id,
+                config.slash_command,
+            )
+            continue
+        try:
+            mode = DeclarativeLoopMode(config, store)
+            workspace.plugins.register_mode(mode, workspace)
+        except Exception:
+            logger.warning(
+                "Custom loop mode '%s' could not be loaded",
+                config.id,
+                exc_info=True,
+            )
+            continue
+        reserved.add(config.slash_command)
+        loaded += 1
+
+    if loaded and "mode" not in reserved:
+        workspace.plugins.register_mode(CustomLoopController(store), workspace)
+
+
+__all__ = ["load_custom_loop_modes"]

--- a/src/qwenpaw/modes/custom_loop/mode.py
+++ b/src/qwenpaw/modes/custom_loop/mode.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""Runtime modes compiled from saved gate pipelines."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from agentscope.message import Msg, TextBlock
+
+from ...app.agent_context import get_current_session_id
+from ...config.config import CustomLoopModeConfig
+from ...loop.compiler import compile_loop_mode
+from ...loop.gates import StopHandler, StopHandlerRegistration
+from ...runtime.hooks import HookContext
+from ...runtime.slash_command_registry import CommandSpec
+from ..base import AgentMode
+
+
+def _system_message(text: str) -> Msg:
+    """Build a small command response."""
+    return Msg(
+        name="system",
+        role="system",
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+def _rewrite_user_message(ctx: HookContext, text: str) -> None:
+    """Replace the dispatched slash command with its task text."""
+    if not ctx.input_msgs:
+        return
+    message = ctx.input_msgs[-1]
+    if isinstance(message, Msg):
+        message.content = [TextBlock(type="text", text=text)]
+
+
+def _reset_mode_handler(ctx: HookContext, mode_id: str) -> None:
+    """Reset one custom mode handler in the current session."""
+    target_name = f"custom:{mode_id}"
+    for mode in ctx.workspace.plugins.modes:
+        if getattr(mode, "name", "") == target_name:
+            mode.handler.reset_session()
+            return
+
+
+@dataclass
+class LoopModeActivationStore:
+    """Per-workspace active custom mode IDs keyed by session."""
+
+    active_modes: dict[str, str] = field(default_factory=dict)
+
+    def activate(self, session_id: str, mode_id: str) -> str | None:
+        """Activate a mode and return the previous mode ID."""
+        previous = self.active_modes.get(session_id)
+        self.active_modes[session_id] = mode_id
+        return previous
+
+    def deactivate(self, session_id: str) -> str | None:
+        """Deactivate and return the previous mode ID."""
+        return self.active_modes.pop(session_id, None)
+
+    def current(self, session_id: str) -> str | None:
+        """Return the active mode ID for a session."""
+        return self.active_modes.get(session_id)
+
+
+class DeclarativeLoopMode(AgentMode):
+    """One saved custom gate pipeline."""
+
+    def __init__(
+        self,
+        config: CustomLoopModeConfig,
+        activation_store: LoopModeActivationStore,
+    ) -> None:
+        self.config = config
+        self.name = f"custom:{config.id}"
+        self._activation_store = activation_store
+        self._handler: StopHandler = compile_loop_mode(config)
+
+    @property
+    def handler(self) -> StopHandler:
+        """Expose the mode-owned handler for tests and introspection."""
+        return self._handler
+
+    def commands(self) -> list[CommandSpec]:
+        """Expose the configured slash command."""
+        return [
+            CommandSpec(
+                name=self.config.slash_command,
+                handler=self._activate_handler,
+                category="custom_loop",
+                help_text=self.config.description,
+                metadata={
+                    "loop_name": self.config.name,
+                    "custom_loop": True,
+                },
+            ),
+        ]
+
+    def setup(self, workspace: object) -> None:
+        """Register command and custom-scoped handler."""
+        super().setup(workspace)
+        workspace.plugins.stop_handlers.append(
+            StopHandlerRegistration(
+                plugin_id="__custom_loop_mode__",
+                handler=self._handler,
+                priority=0,
+                name=f"custom-loop-{self.config.id}",
+                scope=f"custom:{self.config.id}",
+                is_active=self._is_current_session_active,
+            ),
+        )
+
+    def is_active(self, ctx: HookContext) -> bool:
+        """Return whether this mode owns the current session."""
+        return self._activation_store.current(ctx.session_id) == self.config.id
+
+    def on_turn_start(self, ctx: HookContext) -> None:
+        """Reset gates only when this mode is active."""
+        if self.is_active(ctx):
+            self._handler.reset_turn()
+
+    def on_conversation_reset(self, ctx: HookContext) -> None:
+        """Clear this mode's current-session state."""
+        self._handler.reset_session()
+
+    def _is_current_session_active(self) -> bool:
+        session_id = get_current_session_id() or "default"
+        return self._activation_store.current(session_id) == self.config.id
+
+    async def _activate_handler(
+        self,
+        ctx: HookContext,
+        args: str,
+    ) -> Msg | None:
+        """Activate this custom mode for the current conversation."""
+        conflict = self._active_builtin_mode(ctx)
+        if conflict is not None:
+            return _system_message(
+                f"End the active {conflict} mode before switching to "
+                f"/{self.config.slash_command}.",
+            )
+
+        previous = self._activation_store.activate(
+            ctx.session_id,
+            self.config.id,
+        )
+        if previous and previous != self.config.id:
+            _reset_mode_handler(ctx, previous)
+
+        task = args.strip()
+        if not task:
+            return _system_message(
+                f"Custom loop mode '{self.config.name}' is active.",
+            )
+        _rewrite_user_message(ctx, task)
+        return None
+
+    def _active_builtin_mode(self, ctx: HookContext) -> str | None:
+        for mode in ctx.workspace.plugins.modes:
+            if getattr(mode, "name", "") not in ("goal", "mission"):
+                continue
+            if mode.is_active(ctx):
+                return str(mode.name)
+        return None
+
+
+class CustomLoopController(AgentMode):
+    """Own the shared /mode off command and activation cleanup."""
+
+    name = "custom-loop-control"
+
+    def __init__(self, activation_store: LoopModeActivationStore) -> None:
+        self._activation_store = activation_store
+
+    def commands(self) -> list[CommandSpec]:
+        """Expose the shared custom loop control command."""
+        return [
+            CommandSpec(
+                name="mode",
+                handler=self._mode_handler,
+                category="custom_loop",
+                help_text="Disable the active custom loop mode.",
+            ),
+        ]
+
+    def on_conversation_reset(self, ctx: HookContext) -> None:
+        """Clear current custom activation on conversation reset."""
+        self._activation_store.deactivate(ctx.session_id)
+
+    async def _mode_handler(
+        self,
+        ctx: HookContext,
+        args: str,
+    ) -> Msg:
+        """Handle /mode off and report invalid usage."""
+        if args.strip().lower() != "off":
+            return _system_message("Usage: /mode off")
+        previous = self._activation_store.deactivate(ctx.session_id)
+        if previous is None:
+            return _system_message("No custom loop mode is active.")
+        _reset_mode_handler(ctx, previous)
+        return _system_message("Custom loop mode disabled.")
+
+
+__all__ = [
+    "CustomLoopController",
+    "DeclarativeLoopMode",
+    "LoopModeActivationStore",
+]

--- a/src/qwenpaw/modes/goal/goal_mode.py
+++ b/src/qwenpaw/modes/goal/goal_mode.py
@@ -89,6 +89,7 @@ class GoalMode(AgentMode):
 
     def __init__(self) -> None:
         self._sessions: dict[str, GoalSession] = {}
+        self._default_max_iterations = DEFAULT_MAX_ITERATIONS
         self._default_max_tokens = DEFAULT_MAX_TOKENS
         self._handler: StopHandler | None = None
 
@@ -222,6 +223,10 @@ class GoalMode(AgentMode):
         """Register gates into the goal-scoped handler."""
         super().setup(workspace)
 
+        goal_config = workspace.config.running.loop.goal
+        self._default_max_iterations = goal_config.max_iterations
+        self._default_max_tokens = goal_config.max_tokens
+
         handler = StopHandler()
         self._handler = handler
         workspace.plugins.stop_handlers.append(
@@ -240,7 +245,12 @@ class GoalMode(AgentMode):
         doom_gate = create_doom_loop_gate(workspace)
         if doom_gate is not None:
             handler.register(doom_gate)
-        handler.register(GoalTurnGate(self))
+        handler.register(
+            GoalTurnGate(
+                self,
+                max_iterations=self._default_max_iterations,
+            ),
+        )
         handler.register(GoalBudgetGate(self))
         handler.register(RubricGate(self, rubric))
 
@@ -288,7 +298,11 @@ class GoalMode(AgentMode):
         session_key = self._current_session_key(
             ctx,
         )
-        session = GoalSession(goal=goal_text)
+        session = GoalSession(
+            goal=goal_text,
+            max_iterations=self._default_max_iterations,
+            max_tokens=self._default_max_tokens,
+        )
         self._sessions[session_key] = session
 
         logger.info(

--- a/src/qwenpaw/modes/mission/__init__.py
+++ b/src/qwenpaw/modes/mission/__init__.py
@@ -36,6 +36,7 @@ class MissionMode(AgentMode):
 
     def __init__(self) -> None:
         self._gate: MissionGate | None = None
+        self._default_max_iterations = 20
 
     # ── commands ──
 
@@ -80,6 +81,9 @@ class MissionMode(AgentMode):
     def setup(self, workspace: object) -> None:
         """Register MissionGate in a separate handler."""
         super().setup(workspace)
+        self._default_max_iterations = (
+            workspace.config.running.loop.mission.max_iterations
+        )
 
         from .gates import MissionGate as _MG
         from ...loop.gates import (
@@ -148,7 +152,10 @@ class MissionMode(AgentMode):
             start_mission,
         )
 
-        parsed = parse_mission_args(args or "")
+        parsed = parse_mission_args(
+            args or "",
+            default_max_iterations=self._default_max_iterations,
+        )
         task_text = parsed["task_text"]
 
         # --- info sub-commands ---
@@ -172,7 +179,9 @@ class MissionMode(AgentMode):
 
         # --- help / empty ---
         if not task_text or len(task_text.strip()) < 5:
-            return _info_msg(format_help())
+            return _info_msg(
+                format_help(self._default_max_iterations),
+            )
 
         # --- start new mission ---
         workspace_dir = getattr(ctx, "workspace_dir")

--- a/src/qwenpaw/modes/mission/handler.py
+++ b/src/qwenpaw/modes/mission/handler.py
@@ -37,6 +37,7 @@ _MAX_MAX_ITERATIONS = 100
 
 def parse_mission_args(
     raw_args: str,
+    default_max_iterations: int = _DEFAULT_MAX_ITERATIONS,
 ) -> dict[str, Any]:
     """Parse ``[task text] [--verify CMD] [--max-iterations N]``.
 
@@ -46,7 +47,7 @@ def parse_mission_args(
     args: dict[str, Any] = {
         "task_text": "",
         "verify_commands": "",
-        "max_iterations": _DEFAULT_MAX_ITERATIONS,
+        "max_iterations": default_max_iterations,
     }
 
     tokens = raw_args.split()
@@ -151,7 +152,9 @@ def format_list(workspace_dir: Path) -> str:
     return "\n".join(lines)
 
 
-def format_help() -> str:
+def format_help(
+    default_max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+) -> str:
     """Return help text for ``/mission`` without args."""
     return (
         "**Mission Mode**\n\n"
@@ -163,7 +166,7 @@ def format_help() -> str:
         "- `--verify <cmd>` \u2014 verification command\n"
         f"- `--max-iterations <n>` \u2014 "
         f"({_MIN_MAX_ITERATIONS}-{_MAX_MAX_ITERATIONS}, "
-        f"default {_DEFAULT_MAX_ITERATIONS})\n\n"
+        f"default {default_max_iterations})\n\n"
         "Task must be at least 5 characters."
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import pytest
 from qwenpaw.providers import provider_manager as _provider_manager_module
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def capture_qwenpaw_logs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Let caplog see qwenpaw records despite the app logger handler."""
     monkeypatch.setattr(logging.getLogger("qwenpaw"), "propagate", True)

--- a/tests/unit/app/routers/test_loops_router.py
+++ b/tests/unit/app/routers/test_loops_router.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Tests for custom loop mode persistence endpoints."""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.routers.loops import router
+from qwenpaw.config.config import CustomLoopModeConfig, GateInstanceConfig
+
+
+def _mode(mode_id: str = "quality") -> CustomLoopModeConfig:
+    return CustomLoopModeConfig(
+        id=mode_id,
+        name="Quality",
+        slash_command=mode_id,
+        enabled=True,
+        gates=[
+            GateInstanceConfig(
+                id="limit",
+                type="iteration",
+                params={"max_iterations": 20},
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def workspace() -> SimpleNamespace:
+    registry = MagicMock()
+    registry.names.return_value = []
+    return SimpleNamespace(
+        agent_id="default",
+        config=SimpleNamespace(
+            running=SimpleNamespace(
+                loop=SimpleNamespace(custom_modes=[]),
+            ),
+        ),
+        plugins=SimpleNamespace(slash_command_registry=registry),
+    )
+
+
+@pytest.fixture
+def client(workspace: SimpleNamespace):
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    with (
+        patch(
+            "qwenpaw.app.routers.loops.get_agent_for_request",
+            new=AsyncMock(return_value=workspace),
+        ),
+        patch("qwenpaw.app.routers.loops.save_agent_config") as save,
+        patch("qwenpaw.app.routers.loops.schedule_agent_reload") as reload,
+    ):
+        yield TestClient(app), save, reload
+
+
+def test_catalog_exposes_only_builtin_gates(client) -> None:
+    test_client, _, _ = client
+
+    response = test_client.get("/api/loops/gates/catalog")
+
+    assert response.status_code == 200
+    assert {item["type"] for item in response.json()} == {
+        "iteration",
+        "doom_loop",
+        "token_budget",
+        "timeout",
+        "tool_call_budget",
+        "text_response_retry",
+        "completion_rubric",
+    }
+
+
+def test_create_custom_mode_persists_and_schedules_reload(client) -> None:
+    test_client, save, reload = client
+
+    response = test_client.post(
+        "/api/loops/custom",
+        json=_mode().model_dump(),
+    )
+
+    assert response.status_code == 201, response.text
+    save.assert_called_once()
+    reload.assert_called_once()
+
+
+def test_create_rejects_unknown_gate_even_when_disabled(client) -> None:
+    test_client, save, reload = client
+    payload = _mode().model_dump()
+    payload["enabled"] = False
+    payload["gates"][0]["enabled"] = False
+    payload["gates"][0]["type"] = "user_python_gate"
+
+    response = test_client.post("/api/loops/custom", json=payload)
+
+    assert response.status_code == 422
+    assert "Unknown built-in gate type" in response.json()["detail"]
+    save.assert_not_called()
+    reload.assert_not_called()
+
+
+def test_create_rejects_registered_command(client, workspace) -> None:
+    test_client, save, _ = client
+    workspace.plugins.slash_command_registry.names.return_value = ["quality"]
+
+    response = test_client.post(
+        "/api/loops/custom",
+        json=_mode().model_dump(),
+    )
+
+    assert response.status_code == 409
+    save.assert_not_called()

--- a/tests/unit/loop/test_custom_loop_modes.py
+++ b/tests/unit/loop/test_custom_loop_modes.py
@@ -1,0 +1,467 @@
+# -*- coding: utf-8 -*-
+"""Tests for declarative custom loop modes."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from agentscope.message import Msg, TextBlock
+from pydantic import ValidationError
+
+from qwenpaw.config.config import (
+    CustomLoopModeConfig,
+    GateInstanceConfig,
+    LoopConfig,
+)
+from qwenpaw.loop.catalog import get_gate_catalog
+from qwenpaw.loop.compiler import compile_loop_mode
+from qwenpaw.loop.gates import CompletionRubricGate, StopAction
+from qwenpaw.loop.gates.limits import (
+    TimeoutGate,
+    TokenBudgetGate,
+    ToolCallBudgetGate,
+)
+from qwenpaw.modes.custom_loop import (
+    CustomLoopController,
+    DeclarativeLoopMode,
+    LoopModeActivationStore,
+    load_custom_loop_modes,
+)
+from qwenpaw.app.workspace.workspace_plugins import WorkspacePlugins
+from qwenpaw.runtime.slash_command_registry import SlashCommandRegistry
+
+
+def _gate(
+    gate_id: str,
+    gate_type: str,
+    params: dict | None = None,
+) -> GateInstanceConfig:
+    return GateInstanceConfig(
+        id=gate_id,
+        type=gate_type,
+        params=params or {},
+    )
+
+
+def _mode(*gates: GateInstanceConfig) -> CustomLoopModeConfig:
+    return CustomLoopModeConfig(
+        id="quality",
+        name="Quality",
+        slash_command="quality",
+        enabled=True,
+        gates=list(gates),
+    )
+
+
+def test_loop_config_accepts_multiple_custom_modes() -> None:
+    config = LoopConfig(
+        custom_modes=[
+            _mode(_gate("limit", "iteration")),
+            CustomLoopModeConfig(
+                id="research",
+                name="Research",
+                slash_command="research",
+                enabled=True,
+                gates=[_gate("timeout", "timeout")],
+            ),
+        ],
+    )
+
+    assert [mode.id for mode in config.custom_modes] == [
+        "quality",
+        "research",
+    ]
+
+
+def test_loop_config_rejects_gate_outside_builtin_catalog() -> None:
+    with pytest.raises(ValidationError, match="Unknown built-in gate type"):
+        LoopConfig(
+            custom_modes=[
+                CustomLoopModeConfig(
+                    id="unsafe",
+                    name="Unsafe",
+                    slash_command="unsafe",
+                    enabled=False,
+                    gates=[
+                        GateInstanceConfig(
+                            id="python",
+                            type="python_gate",
+                            enabled=False,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+
+def test_custom_mode_rejects_conflicting_completion_gates() -> None:
+    with pytest.raises(ValidationError, match="conflicts"):
+        _mode(
+            _gate("retry", "text_response_retry"),
+            _gate(
+                "rubric",
+                "completion_rubric",
+                {
+                    "criteria": [
+                        {
+                            "id": "done",
+                            "description": "The request is complete",
+                        },
+                    ],
+                },
+            ),
+        )
+
+
+def test_compiler_preserves_pipeline_order() -> None:
+    handler = compile_loop_mode(
+        _mode(
+            _gate("time", "timeout", {"max_seconds": 60}),
+            _gate("limit", "iteration", {"max_iterations": 10}),
+        ),
+    )
+
+    assert [gate.name for gate in handler.gates] == ["time", "limit"]
+    assert [gate.priority for gate in handler.gates] == [0, 10]
+
+
+def test_compiler_validates_disabled_gate_configuration() -> None:
+    mode = CustomLoopModeConfig(
+        id="invalid",
+        name="Invalid",
+        slash_command="invalid",
+        enabled=False,
+        gates=[
+            GateInstanceConfig(
+                id="unknown",
+                type="not_registered",
+                enabled=False,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Unknown built-in gate type"):
+        compile_loop_mode(mode)
+
+
+def test_catalog_contains_only_seven_builtin_gates() -> None:
+    entries = get_gate_catalog().describe()
+
+    assert {entry["type"] for entry in entries} == {
+        "iteration",
+        "doom_loop",
+        "token_budget",
+        "timeout",
+        "tool_call_budget",
+        "text_response_retry",
+        "completion_rubric",
+    }
+
+
+class _FakeModel:
+    def __init__(self, content: dict) -> None:
+        self.content = content
+
+    async def generate_structured_output(self, **kwargs):  # noqa: ANN003
+        del kwargs
+        return SimpleNamespace(content=self.content)
+
+
+def _rubric_context(content: dict) -> dict:
+    state = SimpleNamespace(
+        context=[
+            Msg(
+                name="user",
+                role="user",
+                content=[TextBlock(type="text", text="Finish the task")],
+            ),
+        ],
+    )
+    agent = SimpleNamespace(model=_FakeModel(content), state=state)
+    final = Msg(
+        name="assistant",
+        role="assistant",
+        content=[TextBlock(type="text", text="Completed")],
+    )
+    return {
+        "agent": agent,
+        "final_msg": final,
+        "has_tool_calls": False,
+        "iteration": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_completion_rubric_passes_required_criterion() -> None:
+    gate = CompletionRubricGate(
+        criteria=[
+            {
+                "id": "done",
+                "description": "The request is complete",
+                "required": True,
+                "weight": 1.0,
+            },
+        ],
+    )
+    gate.reset_turn()
+
+    result = await gate.check(
+        _rubric_context(
+            {
+                "criteria": [
+                    {
+                        "id": "done",
+                        "passed": True,
+                        "score": 1.0,
+                        "evidence": ["Completed"],
+                        "feedback": "",
+                    },
+                ],
+            },
+        ),
+    )
+
+    assert result.action == StopAction.TERMINATE
+    assert "passed" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_completion_rubric_requests_bounded_revision() -> None:
+    gate = CompletionRubricGate(
+        criteria=[
+            {
+                "id": "done",
+                "description": "The request is complete",
+                "required": True,
+                "weight": 1.0,
+            },
+        ],
+        max_revisions=1,
+    )
+    gate.reset_turn()
+    context = _rubric_context(
+        {
+            "criteria": [
+                {
+                    "id": "done",
+                    "passed": False,
+                    "score": 0.2,
+                    "evidence": [],
+                    "feedback": "Run verification",
+                },
+            ],
+        },
+    )
+
+    first = await gate.check(context)
+    second = await gate.check(context)
+
+    assert first.action == StopAction.INTERRUPT_AND_CONTINUE
+    assert "Run verification" in gate.build_continuation()
+    assert second.action == StopAction.TERMINATE
+    assert "1 revisions" in second.reason
+
+
+@pytest.mark.asyncio
+async def test_custom_mode_command_activates_current_session() -> None:
+    config = _mode(_gate("limit", "iteration"))
+    store = LoopModeActivationStore()
+    mode = DeclarativeLoopMode(config, store)
+    plugins = SimpleNamespace(
+        slash_command_registry=SlashCommandRegistry(),
+        stop_handlers=[],
+        modes=[mode],
+    )
+    workspace = SimpleNamespace(plugins=plugins)
+    mode.setup(workspace)
+    message = Msg(
+        name="user",
+        role="user",
+        content=[TextBlock(type="text", text="/quality verify it")],
+    )
+    ctx = SimpleNamespace(
+        session_id="session-a",
+        input_msgs=[message],
+        workspace=workspace,
+    )
+
+    response = await mode.commands()[0].handler(ctx, "verify it")
+
+    assert response is None
+    assert store.current("session-a") == "quality"
+    assert message.content[0].text == "verify it"
+
+
+@pytest.mark.asyncio
+async def test_switching_custom_mode_resets_previous_handler() -> None:
+    store = LoopModeActivationStore()
+    quality = DeclarativeLoopMode(
+        _mode(_gate("quality-limit", "iteration")),
+        store,
+    )
+    research_config = CustomLoopModeConfig(
+        id="research",
+        name="Research",
+        slash_command="research",
+        enabled=True,
+        gates=[_gate("research-limit", "iteration")],
+    )
+    research = DeclarativeLoopMode(research_config, store)
+    quality.handler.reset_session = MagicMock()
+    workspace = SimpleNamespace(
+        plugins=SimpleNamespace(modes=[quality, research]),
+    )
+    ctx = SimpleNamespace(
+        session_id="session-a",
+        input_msgs=[],
+        workspace=workspace,
+    )
+
+    await quality.commands()[0].handler(ctx, "")
+    await research.commands()[0].handler(ctx, "")
+
+    assert store.current("session-a") == "research"
+    quality.handler.reset_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_mode_off_clears_activation_and_handler_state() -> None:
+    store = LoopModeActivationStore()
+    quality = DeclarativeLoopMode(
+        _mode(_gate("quality-limit", "iteration")),
+        store,
+    )
+    quality.handler.reset_session = MagicMock()
+    controller = CustomLoopController(store)
+    workspace = SimpleNamespace(
+        plugins=SimpleNamespace(modes=[quality, controller]),
+    )
+    ctx = SimpleNamespace(
+        session_id="session-a",
+        input_msgs=[],
+        workspace=workspace,
+    )
+    store.activate("session-a", "quality")
+
+    response = await controller.commands()[0].handler(ctx, "off")
+
+    assert store.current("session-a") is None
+    assert "disabled" in response.content[0].text
+    quality.handler.reset_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_custom_mode_rejects_active_builtin_mode() -> None:
+    store = LoopModeActivationStore()
+    custom = DeclarativeLoopMode(
+        _mode(_gate("quality-limit", "iteration")),
+        store,
+    )
+    goal = SimpleNamespace(
+        name="goal",
+        is_active=lambda ctx: True,
+    )
+    workspace = SimpleNamespace(
+        plugins=SimpleNamespace(modes=[goal, custom]),
+    )
+    ctx = SimpleNamespace(
+        session_id="session-a",
+        input_msgs=[],
+        workspace=workspace,
+    )
+
+    response = await custom.commands()[0].handler(ctx, "verify it")
+
+    assert store.current("session-a") is None
+    assert "End the active goal mode" in response.content[0].text
+
+
+def test_loader_registers_multiple_enabled_modes() -> None:
+    quality = _mode(_gate("limit", "iteration"))
+    research = CustomLoopModeConfig(
+        id="research",
+        name="Research",
+        slash_command="research",
+        enabled=True,
+        gates=[_gate("time", "timeout")],
+    )
+    disabled = CustomLoopModeConfig(
+        id="draft",
+        name="Draft",
+        slash_command="draft",
+        enabled=False,
+    )
+    config = SimpleNamespace(
+        running=SimpleNamespace(
+            loop=SimpleNamespace(
+                custom_modes=[quality, research, disabled],
+            ),
+        ),
+    )
+    workspace = SimpleNamespace(
+        config=config,
+        plugins=WorkspacePlugins(),
+    )
+
+    load_custom_loop_modes(workspace)
+
+    assert [mode.name for mode in workspace.plugins.modes] == [
+        "custom:quality",
+        "custom:research",
+        "custom-loop-control",
+    ]
+    assert workspace.plugins.slash_command_registry.names() == [
+        "mode",
+        "quality",
+        "research",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_token_budget_accumulates_each_iteration(monkeypatch) -> None:
+    gate = TokenBudgetGate(max_total_tokens=10)
+    gate.reset_turn()
+    monkeypatch.setattr(
+        gate,
+        "_current_usage",
+        lambda: {"prompt_tokens": 4, "completion_tokens": 2},
+    )
+
+    first = await gate.check({"iteration": 1})
+    second = await gate.check({"iteration": 2})
+
+    assert first.action == StopAction.BYPASS
+    assert second.action == StopAction.TERMINATE
+
+
+@pytest.mark.asyncio
+async def test_timeout_gate_uses_monotonic_boundary(monkeypatch) -> None:
+    values = iter([14.0, 16.0])
+    monkeypatch.setattr(
+        "qwenpaw.loop.gates.limits.time",
+        SimpleNamespace(monotonic=lambda: next(values)),
+    )
+    gate = TimeoutGate(max_seconds=5)
+    gate.activate(SimpleNamespace(started_at=10.0))
+
+    before = await gate.check({})
+    after = await gate.check({})
+
+    assert before.action == StopAction.BYPASS
+    assert after.action == StopAction.TERMINATE
+
+
+@pytest.mark.asyncio
+async def test_tool_call_budget_enforces_per_tool_limit() -> None:
+    gate = ToolCallBudgetGate(max_calls=10, per_tool={"search": 1})
+    gate.reset_turn()
+    message = SimpleNamespace(
+        content=[{"type": "tool_call", "name": "search"}],
+    )
+    agent = SimpleNamespace(state=SimpleNamespace(context=[message]))
+
+    result = await gate.check({"iteration": 1, "agent": agent})
+
+    assert result.action == StopAction.TERMINATE
+    assert "search" in result.reason


### PR DESCRIPTION
## Description

Adds declarative, user-editable Agent Loop Modes built exclusively from QwenPaw-owned gates. Users can save multiple custom modes, arrange gates in execution order, edit parameters, and activate one mode per conversation with its slash command.

The backend now provides a strict built-in gate catalog, validates and compiles saved pipelines atomically, owns custom mode lifecycle and scope isolation, and exposes CRUD/catalog APIs. The Console presents Default, Goal, Mission, and every Custom Mode as top-level tabs; built-in structure is locked while values remain editable, and custom pipelines support creation, duplication, deletion, drag sorting, and responsive editing.

**Related Issue:** Relates to [agentscope-ai/QwenPaw#6101](https://github.com/agentscope-ai/QwenPaw/issues/6101)

**Security Considerations:** Custom modes accept declarative parameters only. Gate types are resolved through an explicit built-in whitelist; user code, import paths, callables, and plugin gates cannot be configured.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

## Testing

- Validate catalog, compiler, all seven gate types, activation, mode switching, reset behavior, API persistence, command conflicts, and multi-mode loading with backend unit tests.
- Validate tab identity, template creation, unique commands, pipeline ordering, TypeScript types, and the complete Console test suite.
- Build the Console in test mode to verify production bundling.

## Evidence

```text
Backend tracked unit suite:
4879 passed, 6 skipped

Custom loop and API tests:
20 passed

Frontend full suite:
126 test files passed
1141 tests passed

Static validation:
AST, mypy, Black, flake8, pylint, Prettier passed
TypeScript build and Vite test build passed
```

## Additional Notes

The reviewed design documents and HTML mock are intentionally excluded from this PR.