### PR TITLE
fix(console): restore memory graph file navigation

### DIFF
--- a/console/src/features/files-workspace/FilesWorkspace.module.less
+++ b/console/src/features/files-workspace/FilesWorkspace.module.less
@@ -637,7 +637,7 @@
   .memoryDirectoryGraphButton {
     color: #557766;
     opacity: 1;
-    background: color-mix(in srgb, #557766 12%, var(--files-bg));
+    background: transparent;
     transform: translateY(-50%) scale(1);
   }
 }
@@ -654,9 +654,9 @@
   justify-content: center;
   gap: 5px;
   color: #557766;
-  border: 1px solid color-mix(in srgb, #557766 22%, var(--files-line));
+  border: 0;
   border-radius: 7px;
-  background: color-mix(in srgb, #557766 7%, var(--files-bg));
+  background: transparent;
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
@@ -670,8 +670,7 @@
 
   &:hover {
     color: #557766;
-    border-color: color-mix(in srgb, #557766 42%, var(--files-line));
-    background: color-mix(in srgb, #557766 14%, var(--files-bg));
+    background: color-mix(in srgb, #557766 8%, transparent);
     transform: translateY(-50%) translateY(-1px);
   }
 

--- a/console/src/features/files-workspace/MemoryGraphView.test.tsx
+++ b/console/src/features/files-workspace/MemoryGraphView.test.tsx
@@ -127,6 +127,46 @@ describe("MemoryGraphView", () => {
     );
   });
 
+  it("opens conventional digest paths from legacy graph snapshots", async () => {
+    vi.mocked(agentsApi.getMemoryGraph).mockResolvedValueOnce({
+      version: 1,
+      nodes: [
+        {
+          id: "virtual:wiki",
+          path: "digest/wiki",
+          name: "wiki",
+          description: "",
+          indexed: false,
+          virtual: true,
+        },
+        {
+          id: "digest/wiki/legacy.md",
+          path: "digest/wiki/legacy.md",
+          name: "Legacy",
+          description: "",
+          indexed: true,
+        },
+      ],
+      edges: [
+        {
+          source: "virtual:wiki",
+          target: "digest/wiki/legacy.md",
+          target_anchor: null,
+        },
+      ],
+    });
+
+    render(
+      <MemoryGraphView agentId="agent-a" root="wiki" onOpenFile={openFile} />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Legacy" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "files.memoryGraphOpenFile" }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith("digest", "wiki/legacy.md");
+  });
+
   it("keeps dense graphs readable by limiting persistent labels", async () => {
     const nodes = Array.from({ length: 27 }, (_, index) => ({
       id: `memory/node-${index}.md`,

--- a/console/src/features/files-workspace/MemoryGraphView.tsx
+++ b/console/src/features/files-workspace/MemoryGraphView.tsx
@@ -80,6 +80,30 @@ function shortLabel(node: MemoryGraphNode): string {
   return label.length > 25 ? `${label.slice(0, 22)}…` : label;
 }
 
+function nodeFileTarget(
+  node: MemoryGraphNode,
+): { section: MemorySection; path: string } | null {
+  if (!node.indexed || node.virtual) return null;
+  if (node.section && node.relative_path) {
+    return { section: node.section, path: node.relative_path };
+  }
+
+  // Older graph endpoints did not include navigation metadata. Keep the
+  // standard ReMe/QwenPaw roots openable while the backend is being upgraded.
+  const normalizedPath = node.path.replace(/\\/g, "/").replace(/^\/+/, "");
+  const conventionalRoots: Array<[MemorySection, string]> = [
+    ["digest", "digest/"],
+    ["daily", "memory/"],
+    ["daily", "daily/"],
+  ];
+  for (const [section, prefix] of conventionalRoots) {
+    if (normalizedPath.startsWith(prefix)) {
+      return { section, path: normalizedPath.slice(prefix.length) };
+    }
+  }
+  return null;
+}
+
 function graphDegrees(snapshot: MemoryGraphSnapshot): Map<string, number> {
   const degree = new Map(snapshot.nodes.map((node) => [node.id, 0]));
   snapshot.edges.forEach((edge) => {
@@ -457,6 +481,7 @@ export default function MemoryGraphView({
   }, [baseGraph, offsets]);
   const activeId = hoveredId || selectedId;
   const selected = graphSnapshot?.nodes.find((node) => node.id === selectedId);
+  const selectedFileTarget = selected ? nodeFileTarget(selected) : null;
   const inbound =
     graphSnapshot?.edges.filter((edge) => edge.target === selectedId) ?? [];
   const outbound =
@@ -836,21 +861,21 @@ export default function MemoryGraphView({
               <h2>{nodeLabel(selected)}</h2>
               <code>{selected.path}</code>
               {selected.description && <p>{selected.description}</p>}
-              {selected.indexed &&
-                !selected.virtual &&
-                selected.section &&
-                selected.relative_path && (
-                  <button
-                    type="button"
-                    className={styles.openFileButton}
-                    onClick={() =>
-                      onOpenFile(selected.section!, selected.relative_path!)
-                    }
-                  >
-                    <span>{t("files.memoryGraphOpenFile")}</span>
-                    <ExternalLink size={14} />
-                  </button>
-                )}
+              {selectedFileTarget && (
+                <button
+                  type="button"
+                  className={styles.openFileButton}
+                  onClick={() =>
+                    onOpenFile(
+                      selectedFileTarget.section,
+                      selectedFileTarget.path,
+                    )
+                  }
+                >
+                  <span>{t("files.memoryGraphOpenFile")}</span>
+                  <ExternalLink size={14} />
+                </button>
+              )}
               <div className={styles.linkSection}>
                 <strong>
                   {t("files.memoryGraphOutbound", { count: outbound.length })}


### PR DESCRIPTION
## Description

Restore file navigation from memory graph nodes when a legacy graph snapshot does not include the newer section and relative_path metadata.

The Console now:
- continues to prefer backend-provided navigation metadata;
- derives section-relative targets for conventional digest/, memory/, and daily/ paths as a compatibility fallback;
- keeps virtual and unresolved nodes non-openable;
- simplifies the memory graph entry button styling.

**Related Issue:** None

**Security Considerations:** None. This change only derives section-relative paths for existing indexed graph nodes; workspace path validation remains handled by the existing file API.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend
- [x] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Relevant tests pass locally
- [x] Console type and formatting checks pass
- [x] Tests cover legacy digest path navigation
- [x] Ready for review

## Testing

- npm --prefix console run test:run -- MemoryGraphView.test.tsx
- npm --prefix console run format:check -- --ignore-unknown

## Evidence

- MemoryGraphView.test.tsx: 1 test file passed, 6 tests passed.
- TypeScript: tsc -b --noEmit passed.
- Prettier: all matched files use Prettier code style.

## Additional Notes

The current Python 3.11 pre-commit and Creator backend failures occur during dependency installation because reme-ai==0.4.1.4 is unavailable for that interpreter; they happen before any checks run and are unrelated to these Console-only changes. The AI review job also cannot initialize because REVIEW_DASHSCOPE_API_KEY is not configured in this fork.